### PR TITLE
ITEP-69206 Reduce controller image size

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -62,10 +62,10 @@ list-dependencies:
 	fi
 	@docker run --rm --entrypoint pip $(IMAGE):$(VERSION) freeze --all > $(BUILD_DIR)/$(IMAGE)-pip-deps.txt
 	@echo "Python dependencies listed in $(BUILD_DIR)/$(IMAGE)-pip-deps.txt"
-	@docker run --rm $(RUNTIME_OS_IMAGE) dpkg -l | awk '{ print $$2, $$3, $$4 }' > $(BUILD_DIR)/system-packages.txt
+	@docker run --rm $(RUNTIME_OS_IMAGE) dpkg -l | awk '{ print $$2, $$3, $$4 }' > $(BUILD_DIR)/$(IMAGE)-system-packages.txt
 	@docker run --rm --entrypoint dpkg $(IMAGE):$(VERSION) -l | awk '{ print $$2, $$3, $$4 }' > $(BUILD_DIR)/$(IMAGE)-packages.txt
-	@grep -Fxv -f $(BUILD_DIR)/system-packages.txt $(BUILD_DIR)/$(IMAGE)-packages.txt > $(BUILD_DIR)/$(IMAGE)-apt-deps.txt
-	@rm -rf $(BUILD_DIR)/system-packages.txt $(BUILD_DIR)/$(IMAGE)-packages.txt
+	@grep -Fxv -f $(BUILD_DIR)/$(IMAGE)-system-packages.txt $(BUILD_DIR)/$(IMAGE)-packages.txt > $(BUILD_DIR)/$(IMAGE)-apt-deps.txt
+	@rm -rf $(BUILD_DIR)/$(IMAGE)-system-packages.txt $(BUILD_DIR)/$(IMAGE)-packages.txt
 	@echo "OS dependencies listed in $(BUILD_DIR)/$(IMAGE)-apt-deps.txt"
 
 .PHONY: clean

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -64,9 +64,7 @@ ARG PYTHON_VERSION=3.10
 ENV PYTHON_VERSION=${PYTHON_VERSION}
 ENV WSUSER=scenescape
 ENV SCENESCAPE_HOME=/home/$WSUSER/SceneScape
-ENV WHEEL_DIR=/tmp/wheelhouse
 ENV BUILD_ENV_DIR=/tmp/venv
-ENV RUNTIME_ENV_DIR=/home/$WSUSER/venv
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -75,38 +73,12 @@ USER root
 RUN : \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        libbsd0 \
-        libc6 \
-        libgcc-s1 \
         libgl1 \
-        libglib2.0-0 \
-        libglvnd0 \
-        libglx0 \
-        libgomp1 \
-        libice6 \
-        libmd0 \
-        libpcre3 \
-        libsm6 \
-        libstdc++6 \
-        libtbb12 \
-        libudev1 \
-        libuuid1 \
-        libx11-6 \
-        libxau6 \
-        libxcb1 \
-        libxdmcp6 \
-        libxext6 \
-        zlib1g \
-        libopencv-core4.5d \
-        libopencv-contrib4.5d
-
-RUN : \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
+        libopencv-contrib4.5d \
         libpython3.10 \
         netbase \
-        python-is-python3 \
-        python3-venv \
+        python3-pip \
+    && rm -rf /usr/lib/x86_64-linux-gnu/libLLVM-15.so.1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN : \
@@ -118,19 +90,11 @@ RUN : \
 # TODO: uncomment when issue with accessing the secrets is resolved
 # USER $WSUSER
 
-# setup up runtime Python virtual environment
-RUN : \
-    && mkdir ${RUNTIME_ENV_DIR} \
-    && python3 -m venv ${RUNTIME_ENV_DIR} \
-    && ${RUNTIME_ENV_DIR}/bin/pip3 install --upgrade --no-cache-dir pip \
-    && ${RUNTIME_ENV_DIR}/bin/pip3 install --no-cache-dir wheel
-ENV PATH="${RUNTIME_ENV_DIR}/bin:${PATH}"
-
 # copy installed scenescape packages from the previous stages
-COPY --chown=$WSUSER:$WSUSER --from=scenescape-common-base /usr/local/lib/python${PYTHON_VERSION}/dist-packages/fast_geometry ${RUNTIME_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/fast_geometry
-COPY --chown=$WSUSER:$WSUSER --from=scenescape-common-base /usr/local/lib/python${PYTHON_VERSION}/dist-packages/scene_common ${RUNTIME_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/scene_common
-COPY --chown=$WSUSER:$WSUSER --from=scenescape-controller-builder ${BUILD_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/controller ${RUNTIME_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/controller
-COPY --chown=$WSUSER:$WSUSER --from=scenescape-controller-builder ${BUILD_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/robot_vision ${RUNTIME_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/robot_vision
+COPY --chown=$WSUSER:$WSUSER --from=scenescape-common-base /usr/local/lib/python${PYTHON_VERSION}/dist-packages/fast_geometry /usr/local/lib/python${PYTHON_VERSION}/dist-packages/fast_geometry
+COPY --chown=$WSUSER:$WSUSER --from=scenescape-common-base /usr/local/lib/python${PYTHON_VERSION}/dist-packages/scene_common /usr/local/lib/python${PYTHON_VERSION}/dist-packages/scene_common
+COPY --chown=$WSUSER:$WSUSER --from=scenescape-controller-builder ${BUILD_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/controller /usr/local/lib/python${PYTHON_VERSION}/dist-packages/controller
+COPY --chown=$WSUSER:$WSUSER --from=scenescape-controller-builder ${BUILD_ENV_DIR}/lib/python${PYTHON_VERSION}/site-packages/robot_vision /usr/local/lib/python${PYTHON_VERSION}/dist-packages/robot_vision
 
 # install only required runtime dependencies
 COPY controller/requirements-runtime.txt /tmp

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -40,7 +40,7 @@ ENV WHEEL_DIR=/tmp/wheelhouse
 # Install 3rd party python dependencies
 COPY controller/requirements-buildtime.txt /tmp/
 RUN : \
-    && pip3 install --upgrade -r /tmp/requirements-buildtime.txt \
+    && pip3 install --upgrade --no-cache-dir -r /tmp/requirements-buildtime.txt \
     && rm -rf /tmp/requirements-buildtime.txt
 
 # Build robot vision package
@@ -143,9 +143,8 @@ COPY --chown=$WSUSER:$WSUSER --from=scenescape-controller-builder ${BUILD_ENV_DI
 # install only required runtime dependencies
 COPY controller/requirements-runtime.txt /tmp
 RUN : \
-    && pip3 install --upgrade -r /tmp/requirements-runtime.txt \
-    && rm -rf /tmp/requirements-runtime.txt \
-    && rm -rf /root/.cache/pip
+    && pip3 install --upgrade --no-cache-dir -r /tmp/requirements-runtime.txt \
+    && rm -rf /tmp/requirements-runtime.txt
 
 COPY --chown=$WSUSER:$WSUSER ./controller/src/schema/metadata.schema.json $SCENESCAPE_HOME/schema/metadata.schema.json
 COPY --chown=$WSUSER:$WSUSER ./controller/config/tracker-config.json $SCENESCAPE_HOME/tracker-config.json

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -80,13 +80,37 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 
-COPY --from=scenescape-common-base /var/cache/apt/archives /var/cache/apt/archives
-
-# TODO: copy common dependencies from previous stages instead of install
 RUN : \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        libopencv-dev \
+        libbsd0 \
+        libc6 \
+        libgcc-s1 \
+        libgl1 \
+        libglib2.0-0 \
+        libglvnd0 \
+        libglx0 \
+        libgomp1 \
+        libice6 \
+        libmd0 \
+        libpcre3 \
+        libsm6 \
+        libstdc++6 \
+        libtbb12 \
+        libudev1 \
+        libuuid1 \
+        libx11-6 \
+        libxau6 \
+        libxcb1 \
+        libxdmcp6 \
+        libxext6 \
+        zlib1g \
+        libopencv-core4.5d \
+        libopencv-contrib4.5d
+
+RUN : \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
         libpython3.10 \
         netbase \
         python-is-python3 \
@@ -121,7 +145,7 @@ COPY controller/requirements-runtime.txt /tmp
 RUN : \
     && pip3 install --upgrade -r /tmp/requirements-runtime.txt \
     && rm -rf /tmp/requirements-runtime.txt \
-    && rm -rf ${WHEEL_DIR}
+    && rm -rf /root/.cache/pip
 
 COPY --chown=$WSUSER:$WSUSER ./controller/src/schema/metadata.schema.json $SCENESCAPE_HOME/schema/metadata.schema.json
 COPY --chown=$WSUSER:$WSUSER ./controller/config/tracker-config.json $SCENESCAPE_HOME/tracker-config.json

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -35,14 +35,6 @@ RUN : \
 
 ENV PATH="${BUILD_ENV_DIR}/bin:${PATH}"
 
-ENV WHEEL_DIR=/tmp/wheelhouse
-
-# Install 3rd party python dependencies
-COPY controller/requirements-buildtime.txt /tmp/
-RUN : \
-    && pip3 install --upgrade --no-cache-dir -r /tmp/requirements-buildtime.txt \
-    && rm -rf /tmp/requirements-buildtime.txt
-
 # Build robot vision package
 COPY ./controller/src/robot_vision /tmp/robot_vision
 RUN export OpenCV_DIR="/usr/lib/x86_64-linux-gnu/cmake/opencv4" \

--- a/controller/requirements-buildtime.txt
+++ b/controller/requirements-buildtime.txt
@@ -1,9 +1,0 @@
-# Keep package list in alphabetical order
-coverage
-fastjsonschema
-jsonschema
-numpy==1.26.4
-pybind11
-pytest
-pyyaml
-urllib3

--- a/controller/requirements-runtime.txt
+++ b/controller/requirements-runtime.txt
@@ -1,4 +1,3 @@
-# controller dependencies
 ntplib
 numpy==1.26.4
 open3d-cpu


### PR DESCRIPTION
## 📝 Description

Controller image size (and build time) is reduced by:
- Cleaning up runtime apt dependencies
- Removing venv in runtime stage (minor savings)

Additionally, 
- Python build time dependencies are removed which further reduces overall build time
- A potential file name conflict in `list-dependencies` target in `common.mk` is fixed. This could cause problems if the dependencies list would be generated in parallel (which is not the case now but might be in future)

Overall image size is reduced from ~2.4GB to 1.5GB.

Main size contributors are:
- `libopencv-contrib4.5d` package which delivers OpenCV libraries a.o. required `libopencv-tracking-core` and `libopencv-tracking` libraries. The package cannot be broken down further.
- Python runtime requirements (~1GB). The most space (280MB) is consumed by open3d which is `scene_common` dependency.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works