### PR TITLE
[ITEP-70190] Fix: Prevent race conditions in NetVLAD model downloads

### DIFF
--- a/autocalibration/tools/ondemand_model_loader.py
+++ b/autocalibration/tools/ondemand_model_loader.py
@@ -96,9 +96,9 @@ def ensure_model_exists() -> Optional[Path]:
     logger.error("Failed to download NetVLAD model")
     return None
 
-def sha256sum(filename):
+def sha256sum(filename: Path) -> str:
   h = hashlib.sha256()
-  with open(filename, 'rb') as f:
+  with filename.open('rb') as f:
     for chunk in iter(lambda: f.read(4096), b""):
       h.update(chunk)
   return h.hexdigest()


### PR DESCRIPTION
## 📝 Description

When multiple camcalibration containers start simultaneously (e.g., during docker compose up), they can interfere with each other's NetVLAD model downloads, leading to partial/corrupted files and infinite error loops.

<!--
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works