### PR TITLE
Fix scene performance profiling test

### DIFF
--- a/tests/perf_tests/compose/docker-compose-scene_performance.yml
+++ b/tests/perf_tests/compose/docker-compose-scene_performance.yml
@@ -3,7 +3,7 @@
 
 services:
   test:
-    image: scenescape-manager:latest
+    image: scenescape-controller:latest
     command: bash -c "PYTHONPATH=/workspace tests/perf_tests/scripts/scene_perf_test.sh"
     privileged: true
     environment:

--- a/tests/perf_tests/scripts/scene_perf_test.sh
+++ b/tests/perf_tests/scripts/scene_perf_test.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: (C) 2021 - 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-INPDIR="./sample_data/"
+INPDIR="./sample_data"
 INPUT="apriltag-cam1.mp4"
 INPUT2="apriltag-cam2.mp4"
 INPUT3="apriltag-cam3.mp4"
@@ -13,7 +13,7 @@ JSONFILE2=$( echo $INPUT2 | sed -e 's/mp4/json/g' )
 JSONFILE3=$( echo $INPUT3 | sed -e 's/mp4/json/g' )
 
 VIDEO_FRAMES=1781
-PERF_CMD="controller/tools/analytics/trackrate --frame 1500"
+PERF_CMD="controller/src/controller/tools/analytics/trackrate --frame 1500"
 CONFIG="tests/perf_tests/config/config.json"
 PERF_STR="PERF"
 


### PR DESCRIPTION
## 📝 Description

Fix Scene performance test

JIRA: ITEP-73724

-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [x] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

```
$ make -C tests scene-performance
make: Entering directory '/home/labrat/sbel/scenescape/tests'
+ echo RUNNING TEST scene-performance
RUNNING TEST scene-performance
+ cd ..
+ mkdir -p test_data/perf
+ env IMAGE=scenescape-manager-test:1.4.0-rc1 tests/perf_tests/tc_scene_performance.sh
+ tee -i test_data/perf/scene-performance-2025-08-06-15:11:38.log
Executing: NEX-T10414
Took 0 seconds
Container is ready

Single Camera (Retail)
Running controller/src/controller/tools/analytics/trackrate --frame 1500 --config tests/perf_tests/config/config.json ./sample_data/apriltag-cam1.json
PERF: Total time: 0.6901447772979736 Validation time 0.0008130073547363281, Homography avg 0.69ms Validation avg 0.00ms
PERF: Processed 900 objects shown in 664 frames, total of 998 frames ***
PERF: 324.11 OPS (total) 239.12 FPS (total) ***
PERF: (without getFrame) 1304.07 OPS (total) 962.12 FPS (total) ***
CPU use: 1.52, Wall time 6

Double Camera (Retail)
Running controller/src/controller/tools/analytics/trackrate --frame 1500 --config tests/perf_tests/config/config.json ./sample_data/apriltag-cam1.json ./sample_data/apriltag-cam2.json --skip-validation 
PERF: Total time: 0.8777356147766113 Validation time 0.0012035369873046875, Homography avg 0.58ms Validation avg 0.00ms
PERF: Processed 1077 objects shown in 873 frames, total of 1500 frames ***
PERF: 289.17 OPS (total) 234.39 FPS (total) ***
PERF: (without getFrame) 1227.02 OPS (total) 994.60 FPS (total) ***
CPU use: 1.56, Wall time 6

Triple Camera (Retail)
Running controller/src/controller/tools/analytics/trackrate --frame 1500 --config tests/perf_tests/config/config.json ./sample_data/apriltag-cam1.json ./sample_data/apriltag-cam2.json ./sample_data/apriltag-cam3.json --skip-validation 
PERF: Total time: 1.286149024963379 Validation time 0.0012214183807373047, Homography avg 0.86ms Validation avg 0.00ms
PERF: Processed 1556 objects shown in 1062 frames, total of 1500 frames ***
PERF: 336.67 OPS (total) 229.79 FPS (total) ***
PERF: (without getFrame) 1209.81 OPS (total) 825.72 FPS (total) ***
CPU use: 1.55, Wall time 8
NEX-T10414: PASS
+ echo 'MAKE_TARGET: scene-performance'
+ tee -ia test_data/perf/scene-performance-2025-08-06-15:11:38.log
MAKE_TARGET: scene-performance
+ echo END TEST scene-performance
END TEST scene-performance
make: Leaving directory '/home/labrat/sbel/scenescape/tests'
```

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
