### PR TITLE
ITEP-74810 Manager default Dockerfile healthcheck relies on `postgres`

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -163,7 +163,7 @@ COPY ./manager/config/webserver-init \
      /usr/local/bin/
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD pgrep apache2 || exit 1
+    CMD pgrep postgres || exit 1
 ENTRYPOINT ["/usr/local/bin/scenescape-init"]
 
 # ---------- Manager Test Stage ------------------


### PR DESCRIPTION
## 📝 Description

This PR makes the default health-check dependent on database process, because this Dockerfile default health-check is used only for the database container, while it is being overridden with a curl-based health-check in the docker compose file for the web container, so there is no use in verifying `apache` process here.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
