### PR TITLE
[CI/CD] Remove release branch from Dependabot update target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "GitHub Actions"
-    target-branch: "release-1.4.0"
     groups:
       github-actions-dependency:
         applies-to: version-updates
@@ -30,7 +29,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "Helm charts"
-    target-branch: "release-1.4.0"
     reviewers:
       - "saratpoluri"
       - "dmytroye"
@@ -52,7 +50,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "Dockerfile"
-    target-branch: "release-1.4.0"
     reviewers:
       - "saratpoluri"
       - "dmytroye"
@@ -72,7 +69,6 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Docker Compose"
-    target-branch: "release-1.4.0"
     reviewers:
       - "saratpoluri"
       - "dmytroye"
@@ -93,7 +89,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "pip"
-    target-branch: "release-1.4.0"
     reviewers:
       - "saratpoluri"
       - "dmytroye"


### PR DESCRIPTION
## 📝 Description

This PR removes hardcoded release branch targets from Dependabot configuration to improve CI/CD flexibility. The change ensures that Dependabot dependency updates will be directed to the default branch rather than a specific release branch.

Key changes:

Removed target-branch: "release-1.4.0" from all Dependabot update configurations
Affected all package ecosystems: GitHub Actions, Helm charts, Docker, Docker Compose, and pip

<!--
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [x] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
