### PR TITLE
Bugfix: Intrinsics provided as an array to CamPose

### DIFF
--- a/autocalibration/src/atag_camera_calibration_controller.py
+++ b/autocalibration/src/atag_camera_calibration_controller.py
@@ -11,7 +11,7 @@ from scipy.spatial.transform import Rotation
 
 from scene_common import log
 from scene_common.mqtt import PubSub
-from scene_common.transform import CameraPose, convertToTransformMatrix, getPoseMatrix
+from scene_common.transform import CameraPose, convertToTransformMatrix, getPoseMatrix, CameraIntrinsics
 from scene_common.timestamp import get_iso_time
 
 from atag_camera_calibration import CameraCalibrationApriltag, \
@@ -164,7 +164,7 @@ class ApriltagCameraCalibrationController(CameraCalibrationController):
         # Obtain the frustum view points.
         frustum_2d = cur_cam_calib_obj.getCameraFrustum()
         cam_pose = CameraPose(camera_pose,
-                              intrinsic_matrix_2d)
+                              CameraIntrinsics(intrinsic_matrix_2d))
         # Get respective 2d and 3d points for representation in UI.
         points_3d, points_2d = cur_cam_calib_obj.getPointCorrespondences()
         log.info(("Point correspondences calculated for calibration UI for camera"


### PR DESCRIPTION
## 📝 Description

This pull request is a BugFix for Auto calibration feature. It updates the camera calibration controller to use the `CameraIntrinsics` class when constructing intrinsics for a `CameraPose`.

**Refactoring for type safety and clarity:**

* Updated the import statement in `atag_camera_calibration_controller.py` to include `CameraIntrinsics` from `scene_common.transform`.
* Modified the creation of `CameraPose` in the `generateCalibration` method to wrap the intrinsic matrix with the `CameraIntrinsics` class, ensuring the correct type is used.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
