### PR TITLE
Introducing named proxy template to Scenescape Helm Chart

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -210,16 +210,14 @@ install:
 	@VALUES_FILE=""; \
 	if [ -n "$(http_proxy)" ] || [ -n "$(https_proxy)" ]; then \
 		VALUES_FILE="/tmp/scenescape-proxy-values.yaml"; \
-		echo "proxy:" > $$VALUES_FILE; \
-		echo "  enabled: true" >> $$VALUES_FILE; \
 		if [ -n "$(http_proxy)" ]; then \
-			echo "  httpProxy: \"$(http_proxy)\"" >> $$VALUES_FILE; \
+			echo "httpProxy: \"$(http_proxy)\"" >> $$VALUES_FILE; \
 		fi; \
 		if [ -n "$(https_proxy)" ]; then \
-			echo "  httpsProxy: \"$(https_proxy)\"" >> $$VALUES_FILE; \
+			echo "httpsProxy: \"$(https_proxy)\"" >> $$VALUES_FILE; \
 		fi; \
 		if [ -n "$(no_proxy)" ]; then \
-			echo "  noProxy: \"$(no_proxy)\"" >> $$VALUES_FILE; \
+			echo "noProxy: \"$(no_proxy)\"" >> $$VALUES_FILE; \
 		fi; \
 		VALUES_FILE="-f $$VALUES_FILE"; \
 	fi; \

--- a/kubernetes/scenescape-chart/README.md
+++ b/kubernetes/scenescape-chart/README.md
@@ -63,11 +63,9 @@ PostgreSQL database server which stores static information used by the web UI an
 If you're deploying SceneScape in an environment that requires proxy access to external resources, use the following best-practice values for `noProxy`:
 
 ```yaml
-proxy:
-  enabled: true
-  httpProxy: "http://your-proxy-server:port"
-  httpsProxy: "https://your-proxy-server:port"
-  noProxy: "localhost,127.0.0.1,.local,.svc,.svc.cluster.local,10.96.0.0/12,10.244.0.0/16,172.17.0.0/16"
+httpProxy: "http://your-proxy-server:port"
+httpsProxy: "https://your-proxy-server:port"
+noProxy: "localhost,127.0.0.1,.local,.svc,.svc.cluster.local,10.96.0.0/12,10.244.0.0/16,172.17.0.0/16"
 ```
 
 For a detailed explanation of what to put in `no_proxy` and why, see the [Proxy Configuration section in the top-level README](../README.md#proxy-configuration).

--- a/kubernetes/scenescape-chart/templates/_helpers.tpl
+++ b/kubernetes/scenescape-chart/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "proxy_envs" }}
+- name: HTTP_PROXY
+  value: {{ .Values.httpProxy }}
+- name: HTTPS_PROXY
+  value: {{ .Values.httpsProxy }}
+- name: NO_PROXY
+  value: {{ .Values.noProxy }}
+- name: http_proxy
+  value: {{ .Values.httpProxy }}
+- name: https_proxy
+  value: {{ .Values.httpsProxy }}
+- name: no_proxy
+  value: {{ .Values.noProxy }}
+{{- end }}

--- a/kubernetes/scenescape-chart/templates/_helpers.tpl
+++ b/kubernetes/scenescape-chart/templates/_helpers.tpl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 {{- define "proxy_envs" }}
 - name: HTTP_PROXY
   value: {{ .Values.httpProxy }}

--- a/kubernetes/scenescape-chart/templates/broker-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/broker-dep.yaml
@@ -21,15 +21,8 @@ spec:
       containers:
         - name: broker
           image: {{ .Values.broker.image }}:{{ .Values.broker.tag }}
-{{ if .Values.proxy.enabled }}
           env:
-            - name: http_proxy
-              value: {{ .Values.proxy.http_proxy | quote }}
-            - name: https_proxy
-              value: {{ .Values.proxy.https_proxy | quote }}
-            - name: no_proxy
-              value: {{ .Values.proxy.no_proxy | quote }}
-{{ end }}
+            {{ include "proxy_envs" . | indent 12 }}
           ports:
             - containerPort: 1883
             - containerPort: 1884

--- a/kubernetes/scenescape-chart/templates/camcalibration-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/camcalibration-dep.yaml
@@ -36,20 +36,7 @@ spec:
           env:
           - name: EGL_PLATFORM
             value: surfaceless
-{{- if .Values.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.proxy.noProxy }}
-          - name: http_proxy
-            value: {{ .Values.proxy.httpProxy }}
-          - name: https_proxy
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: no_proxy
-            value: {{ .Values.proxy.noProxy }}
-{{- end }}
+          {{ include "proxy_envs" . | indent 10 }}
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/kubernetes/scenescape-chart/templates/kubeclient-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/kubeclient-dep.yaml
@@ -57,20 +57,7 @@ spec:
             value: {{ $pullSecret.name | quote }}
           {{- end }}
           {{- end }}
-{{- if .Values.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.proxy.noProxy }}
-          - name: http_proxy
-            value: {{ .Values.proxy.httpProxy }}
-          - name: https_proxy
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: no_proxy
-            value: {{ .Values.proxy.noProxy }}
-{{- end }}
+            {{ include "proxy_envs" . | indent 12 }}
           imagePullPolicy: Always
           readinessProbe:
             exec:

--- a/kubernetes/scenescape-chart/templates/mediaserver-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/mediaserver-dep.yaml
@@ -18,11 +18,9 @@ spec:
         app: {{ .Release.Name }}-mediaserver
     spec:
       securityContext:
-        privileged: false
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
-        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL
@@ -31,7 +29,12 @@ spec:
           name: {{ .Release.Name }}-mediaserver
           imagePullPolicy: IfNotPresent
           securityContext:
+            privileged: false
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+            drop:
+              - ALL
           livenessProbe:
             tcpSocket:
               port: 8554

--- a/kubernetes/scenescape-chart/templates/mediaserver-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/mediaserver-dep.yaml
@@ -21,9 +21,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
-        capabilities:
-          drop:
-          - ALL
       containers:
         - image: {{ .Values.mediaserver.image }}:{{ .Values.mediaserver.tag }}
           name: {{ .Release.Name }}-mediaserver
@@ -33,8 +30,8 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
-            drop:
-              - ALL
+              drop:
+                - ALL
           livenessProbe:
             tcpSocket:
               port: 8554

--- a/kubernetes/scenescape-chart/templates/models-job.yaml
+++ b/kubernetes/scenescape-chart/templates/models-job.yaml
@@ -30,21 +30,8 @@ spec:
         image: {{ .Values.repository }}/{{ .Values.initModels.image }}:{{ .Chart.AppVersion }}
         name: {{ .Release.Name }}-{{ .Values.initModels.image }}-container
         imagePullPolicy: Always
-{{- if .Values.proxy.enabled }}
         env:
-        - name: HTTP_PROXY
-          value: {{ .Values.proxy.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxy.noProxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy.httpProxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: no_proxy
-          value: {{ .Values.proxy.noProxy }}
-{{- end }}
+          {{ include "proxy_envs" . | indent 12 }}
         volumeMounts:
         - mountPath: /root/models-storage/models
           name: models-storage

--- a/kubernetes/scenescape-chart/templates/ntp-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/ntp-dep.yaml
@@ -36,20 +36,7 @@ spec:
           env:
           - name: NTP_SERVERS
             value: {{ .Values.ntpserv.ntpServers }}
-{{- if .Values.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.proxy.noProxy }}
-          - name: http_proxy
-            value: {{ .Values.proxy.httpProxy }}
-          - name: https_proxy
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: no_proxy
-            value: {{ .Values.proxy.noProxy }}
-{{- end }}
+            {{ include "proxy_envs" . | indent 10 }}
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/kubernetes/scenescape-chart/templates/pgserver-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/pgserver-dep.yaml
@@ -33,7 +33,7 @@ spec:
                   key: DATABASE_PASSWORD
             - name: POSTGRES_DB
               value: "scenescape"
-              {{ include "proxy_envs" . | indent 10 }}
+              {{ include "proxy_envs" . | indent 12 }}
           imagePullPolicy: Always
           securityContext:
           ports:

--- a/kubernetes/scenescape-chart/templates/pgserver-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/pgserver-dep.yaml
@@ -52,20 +52,7 @@ spec:
           - name: DBROOT
             value: {{ .Values.dbroot }}
 {{- end }}
-{{- if .Values.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.proxy.noProxy }}
-          - name: http_proxy
-            value: {{ .Values.proxy.httpProxy }}
-          - name: https_proxy
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: no_proxy
-            value: {{ .Values.proxy.noProxy }}
-{{- end }}
+            {{ include "proxy_envs" . | indent 10 }}
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/kubernetes/scenescape-chart/templates/sample-data-job.yaml
+++ b/kubernetes/scenescape-chart/templates/sample-data-job.yaml
@@ -38,21 +38,8 @@ spec:
         image: {{ .Values.repository }}/{{ .Values.initModels.image }}:{{ .Chart.AppVersion }}
         name: {{ .Release.Name }}-{{ .Values.initModels.image }}-container
         imagePullPolicy: Always
-{{- if .Values.proxy.enabled }}
         env:
-        - name: HTTP_PROXY
-          value: {{ .Values.proxy.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxy.noProxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy.httpProxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: no_proxy
-          value: {{ .Values.proxy.noProxy }}
-{{- end }}
+          {{ include "proxy_envs" . | indent 12 }}
         volumeMounts:
         - mountPath: /root/sample-data-storage/sample_data
           name: sample-data-storage

--- a/kubernetes/scenescape-chart/templates/scene-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/scene-dep.yaml
@@ -42,20 +42,7 @@ spec:
           env:
           - name: VDMS_HOSTNAME
             value: vdms.{{ .Release.Namespace }}.svc.cluster.local
-{{- if .Values.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.proxy.noProxy }}
-          - name: http_proxy
-            value: {{ .Values.proxy.httpProxy }}
-          - name: https_proxy
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: no_proxy
-            value: {{ .Values.proxy.noProxy }}
-{{- end }}
+            {{ include "proxy_envs" . | indent 10 }}
           imagePullPolicy: Always
           readinessProbe:
             exec:

--- a/kubernetes/scenescape-chart/templates/secrets-job.yaml
+++ b/kubernetes/scenescape-chart/templates/secrets-job.yaml
@@ -51,20 +51,7 @@ spec:
           value: {{ .Release.Name }}-
         - name: CERTDOMAIN
           value: {{ .Release.Namespace }}.svc.cluster.local
-{{- if .Values.proxy.enabled }}
-        - name: HTTP_PROXY
-          value: {{ .Values.proxy.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxy.noProxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy.httpProxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: no_proxy
-          value: {{ .Values.proxy.noProxy }}
-{{- end }}
+          {{- include "proxy_envs" . | indent 8 }}
       restartPolicy: Never
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/kubernetes/scenescape-chart/templates/sources-job.yaml
+++ b/kubernetes/scenescape-chart/templates/sources-job.yaml
@@ -23,21 +23,7 @@ spec:
         image: {{ .Values.repository }}/scenescape-sources:{{ .Chart.AppVersion }}
         name: scenescape-sources-container
         imagePullPolicy: Always
-{{- if .Values.proxy.enabled }}
-        env:
-        - name: HTTP_PROXY
-          value: {{ .Values.proxy.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxy.noProxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy.httpProxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: no_proxy
-          value: {{ .Values.proxy.noProxy }}
-{{- end }}
+        {{ include "proxy_envs" . | indent 12 }}
       restartPolicy: Never
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/kubernetes/scenescape-chart/templates/tests-job.yaml
+++ b/kubernetes/scenescape-chart/templates/tests-job.yaml
@@ -29,21 +29,8 @@ spec:
         image: {{ .Values.repository }}/{{ .Values.tests.image }}:{{ .Chart.AppVersion }}
         name: {{ .Release.Name }}-{{ .Values.tests.image }}-container
         imagePullPolicy: Always
-{{- if .Values.proxy.enabled }}
         env:
-        - name: HTTP_PROXY
-          value: {{ .Values.proxy.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxy.noProxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy.httpProxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: no_proxy
-          value: {{ .Values.proxy.noProxy }}
-{{- end }}
+          {{ include "proxy_envs" . | indent 12 }}
         volumeMounts:
         - mountPath: /root/tests-storage/tests
           name: tests-storage

--- a/kubernetes/scenescape-chart/templates/validation-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/validation-dep.yaml
@@ -88,21 +88,8 @@ spec:
       containers:
       - name: frps
         image: {{ .Values.tests.frpsImage }}
-{{- if .Values.proxy.enabled }}
         env:
-        - name: HTTP_PROXY
-          value: {{ .Values.proxy.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxy.noProxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy.httpProxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: no_proxy
-          value: {{ .Values.proxy.noProxy }}
-{{- end }}
+          {{ include "proxy_envs" . | indent 12 }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/frp/frps.toml
@@ -130,21 +117,8 @@ spec:
       containers:
       - name: frpc
         image: {{ .Values.tests.frpcImage }}
-{{- if .Values.proxy.enabled }}
         env:
-        - name: HTTP_PROXY
-          value: {{ .Values.proxy.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxy.noProxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy.httpProxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy.httpsProxy }}
-        - name: no_proxy
-          value: {{ .Values.proxy.noProxy }}
-{{- end }}
+          {{ include "proxy_envs" . | indent 12 }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/frp/frpc.toml

--- a/kubernetes/scenescape-chart/templates/vdms-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/vdms-dep.yaml
@@ -29,20 +29,7 @@ spec:
             value: /run/secrets/certs/scenescape-vdms-s.crt
           - name: OVERRIDE_key_file
             value: /run/secrets/certs/scenescape-vdms-s.key
-{{- if .Values.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.proxy.noProxy }}
-          - name: http_proxy
-            value: {{ .Values.proxy.httpProxy }}
-          - name: https_proxy
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: no_proxy
-            value: {{ .Values.proxy.noProxy }}
-{{- end }}
+            {{- include "proxy_envs" . | indent 10 }}
           imagePullPolicy: Always
           resources: {}
           volumeMounts:

--- a/kubernetes/scenescape-chart/templates/web-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/web-dep.yaml
@@ -64,7 +64,7 @@ spec:
           - name: DBROOT
             value: {{ .Values.dbroot }}
 {{- end }}
-            {{ include "proxy_envs" . | indent 12 }}
+            {{ include "proxy_envs" . | indent 10 }}
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/kubernetes/scenescape-chart/templates/web-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/web-dep.yaml
@@ -54,20 +54,7 @@ spec:
           - name: DBROOT
             value: {{ .Values.dbroot }}
 {{- end }}
-{{- if .Values.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.proxy.noProxy }}
-          - name: http_proxy
-            value: {{ .Values.proxy.httpProxy }}
-          - name: https_proxy
-            value: {{ .Values.proxy.httpsProxy }}
-          - name: no_proxy
-            value: {{ .Values.proxy.noProxy }}
-{{- end }}
+            {{ include "proxy_envs" . | indent 12 }}
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/kubernetes/scenescape-chart/values.yaml
+++ b/kubernetes/scenescape-chart/values.yaml
@@ -100,7 +100,6 @@ userAccessConfig:
 # PVC
 pvc:
   storageClassName: ""
-  hookWeight: -10
 
 # External access
 service:
@@ -142,11 +141,9 @@ debug: false
 chartdebug: false
 
 # Proxy configuration
-proxy:
-  enabled: false
-  httpProxy: ""
-  httpsProxy: ""
-  noProxy: "localhost,127.0.0.1,.local,.svc,.cluster.local,10.244.0.0/16,10.96.0.0/12"
+httpProxy: ""
+httpsProxy: ""
+noProxy: "localhost,127.0.0.1,.local,.svc,.cluster.local,10.244.0.0/16,10.96.0.0/12"
 
 # enable to pull scenescape-sources image during deployment
 sources:

--- a/kubernetes/template/kind-config.template
+++ b/kubernetes/template/kind-config.template
@@ -7,10 +7,6 @@ containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:{KINDREGPORT}"]
     endpoint = ["http://{KINDREG}:5000"]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-    endpoint = ["https://dockerhubcache.caas.intel.com"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."dockerhubcache.caas.intel.com".tls]
-    insecure_skip_verify = true
 nodes:
 - role: control-plane
   kubeadmConfigPatches:

--- a/kubernetes/template/kind-config.template
+++ b/kubernetes/template/kind-config.template
@@ -7,6 +7,10 @@ containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:{KINDREGPORT}"]
     endpoint = ["http://{KINDREG}:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+    endpoint = ["https://dockerhubcache.caas.intel.com"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."dockerhubcache.caas.intel.com".tls]
+    insecure_skip_verify = true
 nodes:
 - role: control-plane
   kubeadmConfigPatches:


### PR DESCRIPTION
## 📝 Description

For common configuration in multiple k8s resources, it's a good practice to use named templates. This change introduces named template for proxy env variables.
What this gives us:
If we'd like to add some new proxy var, e.g. FTP proxy, we only add it in a template and it's propagated to all deployments.

This change also moves security context in one deployment because of warnings in `helm install` .

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
