### PR TITLE
Revert "ITEP-78937: Update autocalib image to run as non root user"

### DIFF
--- a/.github/resources/sdl/.trivyignore.yaml
+++ b/.github/resources/sdl/.trivyignore.yaml
@@ -7,10 +7,12 @@ misconfigurations:
   - id: AVD-DS-0002
     paths:
       - "manager/Dockerfile"
+      - "autocalibration/Dockerfile"
     statement: Current implementation require root user
   # Helm chart
   - id: AVD-KSV-0005
     paths:
+      - "kubernetes/scenescape-chart/templates/camcalibration-dep.yaml"
       - "kubernetes/scenescape-chart/templates/web-dep.yaml"
     statement: Current implementation requires admin capabilities
   - id: AVD-KSV-0014
@@ -25,5 +27,6 @@ misconfigurations:
     statement: Current implementation requires these containers to write to filesystem
   - id: AVD-KSV-0017
     paths:
+      - "kubernetes/scenescape-chart/templates/camcalibration-dep.yaml"
       - "kubernetes/scenescape-chart/templates/web-dep.yaml"
     statement: Current implementation requires privileged container

--- a/autocalibration/Dockerfile
+++ b/autocalibration/Dockerfile
@@ -76,9 +76,8 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/open-edge-platform/scenescape"
 LABEL org.opencontainers.image.documentation="https://github.com/open-edge-platform/scenescape/blob/main/autocalibration/docs/user-guide/overview.md"
 
-# Define build arguments and environment variables first
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+# Define environment variables first
+ARG USER_ID
 ARG CERTDOMAIN=scenescape.intel.com
 ENV CERTDOMAIN=${CERTDOMAIN}
 ENV DEBIAN_FRONTEND=noninteractive
@@ -92,20 +91,18 @@ ENV NETVLAD_MODEL_DIR="/usr/local/lib/python3.10/dist-packages/third_party/netvl
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
-    libgl1 libegl1 libglib2.0-0 libgomp1 python3 python3-pip wget && \
+    bindfs gosu libgl1 libegl1 libglib2.0-0 libgomp1 python3 python3-pip sudo wget && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-# Add user with specific UID/GID (not system user)
-RUN groupadd -g $GROUP_ID $WSUSER && \
-    useradd -u $USER_ID -g $GROUP_ID -m -s /bin/bash $WSUSER && \
+# Add user (this rarely changes)
+RUN useradd -r -m -s /bin/bash $WSUSER && \
     usermod -a -G video,users $WSUSER && \
     chmod a+rX /home/$WSUSER
 
-# Create model directory and tmp directory for healthcheck
-RUN mkdir -p $NETVLAD_MODEL_DIR /tmp && \
-    chown -R $WSUSER:$WSUSER $NETVLAD_MODEL_DIR && \
-    chmod a=rwx,+t /tmp
+# Create model directory for on-demand downloads
+RUN mkdir -p $NETVLAD_MODEL_DIR && \
+    chown -R $WSUSER:$WSUSER $NETVLAD_MODEL_DIR
 
 # Copy scene_common and fast_geometry from builder stage BEFORE installing other packages
 COPY --from=camcalibration-builder /usr/local/lib/python3.10/dist-packages/fast_geometry /usr/local/lib/python3.10/dist-packages/fast_geometry
@@ -133,30 +130,25 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     rm -rf /tmp/*.whl
 
 # Copy application code (this changes frequently)
-COPY --chown=$WSUSER:$WSUSER autocalibration/src/camcalibration $SCENESCAPE_HOME/camcalibration
+COPY autocalibration/src/camcalibration $SCENESCAPE_HOME/
 RUN chmod +x $SCENESCAPE_HOME/camcalibration
-COPY --chown=$WSUSER:$WSUSER autocalibration/src/*.py $SCENESCAPE_HOME/
-COPY --chown=$WSUSER:$WSUSER autocalibration/tools/ondemand_model_loader.py /usr/local/bin/download_models.py
+COPY autocalibration/src/*.py $SCENESCAPE_HOME/
+COPY autocalibration/src/camcalibration-init /usr/local/bin/
+RUN chmod +x /usr/local/bin/camcalibration-init
 
+# Create a startup script that ensures model directory permissions and checks NetVLAD model
 RUN echo '#!/bin/bash\n\
 set -e\n\
+chown -R $WSUSER:$WSUSER $NETVLAD_MODEL_DIR\n\
 if [ "$SKIP_MODEL_DOWNLOAD" != "1" ]; then\n\
     echo "Checking NetVLAD model..."\n\
     python3 /usr/local/bin/download_models.py\n\
 fi\n\
-touch /tmp/healthy\n\
-exec "$@"\n' > /usr/local/bin/startup.sh && \
-    chmod +x /usr/local/bin/startup.sh && \
-    chown $WSUSER:$WSUSER /usr/local/bin/startup.sh
+exec "$@"\n' > /usr/local/bin/startup.sh && chmod +x /usr/local/bin/startup.sh
 
-# Switch to non-root user
-USER $WSUSER
-WORKDIR $SCENESCAPE_HOME
-
-HEALTHCHECK --interval=30s --timeout=5s --retries=10 \
-    CMD pgrep -f python3 || exit 1
-
-ENTRYPOINT ["/usr/local/bin/startup.sh", "/home/scenescape/SceneScape/camcalibration"]
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD pgrep python3 || exit 1
+ENTRYPOINT ["/usr/local/bin/startup.sh", "/usr/local/bin/camcalibration-init"]
 
 # ---------- Cam Calibration Test Stage ------------------
 # This stage is meant to be used for test execution (not for final runtime)
@@ -164,18 +156,9 @@ FROM camcalibration-runtime AS camcalibration-test
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SKIP_MODEL_DOWNLOAD=1
 
-# Switch back to root to install test dependencies
-USER root
-
 # Install Python test dependencies
 RUN pip3 install --upgrade --no-cache-dir coverage pytest
 
-# Switch back to non-root user for tests
-USER $WSUSER
-
-# Tests expect to run from /workspace where test files are mounted
-WORKDIR /workspace
-
-# Use exec form with bash to properly handle the command string
-ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["bash"]
+RUN : \
+    ; eval WSHOME=~$WSUSER \
+    ;

--- a/autocalibration/src/camcalibration-init
+++ b/autocalibration/src/camcalibration-init
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: (C) 2021 - 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+WSUSER=${WSUSER:-scenescape}
+WORKSPACE=${WORKSPACE:-/workspace}
+SECRETSDIR=${SECRETSDIR:-${WORKSPACE}/secrets}
+SSCAPEDIR=SceneScape
+RUNSECRETS=/run/secrets
+START_CAMCALIB=0
+
+eval WSHOME=~${WSUSER}
+SSCAPEDIR="${WSHOME}/${SSCAPEDIR}"
+
+map_dir() {
+    local SRC=$1
+    local DEST=$2
+    local DUID=$3
+    local DGID=$4
+
+    local SUID=$(stat -c '%u' "${SRC}")
+    local SGID=$(stat -c '%g' "${SRC}")
+
+    mkdir -p "${DEST}"
+    chown "${DUID}:${DGID}" "${DEST}"
+    bindfs -o nonempty --map="${SUID}/${DUID}:@${SGID}/@${DGID}" "${SRC}" "${DEST}"
+}
+
+if [ -d "${WORKSPACE}" ]; then
+    WSDIR=${HOSTDIR:-${WORKSPACE}}
+    WSUID=$(stat -c '%u' "${WORKSPACE}"/* | sort -rn | head -1)
+    WSGID=$(stat -c '%g' "${WORKSPACE}"/* | sort -rn | head -1)
+
+    if ((WSUID == 0 || WSGID == 0)); then
+        echo "Owner of ${WSDIR} is system root."
+        ls -Flan "${WORKSPACE}"
+        exit 1
+    fi
+
+    chown "${WSUID}:${WSGID}" "${WORKSPACE}"
+
+    if [ "${WSGID}" != "$(id -g ${WSUSER})" ]; then
+        groupmod -g "${WSGID}" "${WSUSER}"
+    fi
+
+    if [ "${WSGID}" != "$(id -g ${WSUSER})" ] || [ "${WSUID}" != "$(id -u ${WSUSER})" ]; then
+        usermod -u "${WSUID}" -g "${WSGID}" "${WSUSER}"
+    fi
+
+    if [ -n "${HOSTDIR}" ]; then
+        mkdir -p "${HOSTDIR}"
+        mount --bind "${WORKSPACE}" "${HOSTDIR}"
+        cd "${HOSTDIR}"
+    else
+        cd "${WORKSPACE}"
+    fi
+else
+    cd "${SSCAPEDIR}"
+fi
+
+if [ -n "${SECRETSDIR}" ] ; then
+    case "${SECRETSDIR}" in
+        /* ) ;;
+        * ) SECRETSDIR=${WORKSPACE}/${SECRETSDIR} ;;
+    esac
+fi
+
+if [ ! -e ${RUNSECRETS} ] && [ -n "${SECRETSDIR}" ] && [ -d "${SECRETSDIR}" ] ; then
+    echo Found some secrets
+    ln -s ${SECRETSDIR} ${RUNSECRETS}
+fi
+
+DBROOT=${DBROOT:-${WORKSPACE}}
+case "${DBROOT}" in
+    /*) ;;
+    *) DBROOT=${WORKSPACE}/${DBROOT} ;;
+esac
+
+while [ $# -gt 0 -a x$(expr substr "$1" 1 2) = "x--" ] ; do
+    case "$1" in
+        --shell)
+            DO_SHELL=user
+            shift
+            ;;
+        --super-shell)
+            DO_SHELL=super
+            shift
+            ;;
+        *)
+            echo "Unknown flag $1"
+            exit 1
+    esac
+done
+
+echo "TIMEZONE IS" ${TZ}
+
+WAITPID=""
+
+if [ "$1" = "camcalibration" ] || [ "$1" = "server" ]; then
+    START_CAMCALIB=1
+    shift
+fi
+
+while [ $# -gt 0 -a x$(expr substr "${1:-empty}" 1 2) = "x--" ] ; do
+    case "$1" in
+        --broker)
+            BROKER="$1 $2"
+            shift 2
+            ;;
+        --brokerauth)
+            BROKERAUTH="$2"
+            shift 2
+            ;;
+        --resturl)
+            RESTURL="$1 $2"
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ ${START_CAMCALIB} = 1 ] ; then
+    echo "Starting auto camera calibration service"
+
+    BROKERAUTH=${BROKERAUTH:-${RUNSECRETS}/calibration.auth}
+    RESTAUTH=${RESTAUTH:-${RUNSECRETS}/calibration.auth}
+
+    map_dir "${DBROOT}/media" "${SSCAPEDIR}/media"
+    chown -R "${WSUSER}.${WSUSER}" "${DBROOT}/datasets"
+    map_dir "${DBROOT}/datasets" "${SSCAPEDIR}/datasets"
+
+    exec gosu ${WSUSER} ${SSCAPEDIR}/camcalibration \
+            --restauth ${RESTAUTH} ${RESTURL} \
+            --brokerauth ${BROKERAUTH} ${BROKER} &
+    WAITPID=$!
+    set --
+fi
+
+echo "Took ${SECONDS} seconds"
+echo "Container is ready"
+
+# for kubernetes readinessProbe
+touch /tmp/healthy
+
+if [ -n "${WAITPID}" ]; then
+    tail --pid="${WAITPID}" -f /dev/null
+    wait "${WAITPID}"
+else
+    if [ "${DO_SHELL}" = 'user' ] ; then
+        if [ $# -gt 0 ] ; then
+            echo "Starting shell with command: $@"
+            IFS=
+            sudo -u ${WSUSER} -E -H -s $@
+        else
+            echo "Starting shell"
+            su ${WSUSER}
+        fi
+    elif [ "${DO_SHELL}" = 'super' ] ; then
+        if [ $# -gt 0 ] ; then
+            echo "Starting super shell with command: $@"
+            /bin/bash -c "$@"
+        else
+            echo "Starting super shell"
+            /bin/bash
+        fi
+    else
+        if [ $# -gt 0 ] ; then
+            IFS=
+            sudo -u ${WSUSER} -E -H $@
+        else
+            su ${WSUSER}
+        fi
+    fi
+fi
+
+exit $?

--- a/kubernetes/scenescape-chart/templates/camcalibration-dep.yaml
+++ b/kubernetes/scenescape-chart/templates/camcalibration-dep.yaml
@@ -7,6 +7,8 @@ metadata:
   name: {{ .Release.Name }}-camcalibration-dep
   labels:
     app: {{ .Release.Name }}-camcalibration
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/camcalibration: unconfined
 spec:
   replicas: 1
   selector:
@@ -19,8 +21,8 @@ spec:
     spec:
       shareProcessNamespace: true
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 0
+        runAsGroup: 0
       initContainers:
         - name: wait-for-web-initcontainer
           image: busybox
@@ -29,44 +31,24 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             {{ include "defaultContainerSecurityContext" . | indent 12 }}
-        - name: fix-permissions-initcontainer
-          image: busybox
-          command: ["/bin/sh", "-c", "chown -R 1000:1000 /data/media /data/datasets && echo 'Permissions fixed'"]
-          securityContext:
-            runAsUser: 0
-            runAsGroup: 0
-          volumeMounts:
-          - mountPath: /data/media
-            name: media-storage
-          - mountPath: /data/datasets
-            name: datasets-storage
       containers:
         - args:
-          - --restauth
-          - /run/secrets/calibration.auth
-          - --resturl
-          - https://web.{{ .Release.Namespace }}.svc.cluster.local/api/v1
-          - --brokerauth
-          - /run/secrets/calibration.auth
+          - camcalibration
           - --broker
           - broker.{{ .Release.Namespace }}.svc.cluster.local
+          - --resturl
+          - https://web.{{ .Release.Namespace }}.svc.cluster.local/api/v1
           image: {{ .Values.repository }}/{{ .Values.camcalibration.image }}:{{ .Chart.AppVersion }}
           name: {{ .Release.Name }}-camcalibration
           env:
           - name: EGL_PLATFORM
             value: surfaceless
-          - name: NETVLAD_MODEL_DIR
-            value: /usr/local/lib/python3.10/dist-packages/third_party/netvlad
           {{ include "proxy_envs" . | indent 10 }}
           imagePullPolicy: Always
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
+            privileged: true
             capabilities:
-              drop:
-              - ALL
+              add: ["SYS_ADMIN"]
           readinessProbe:
             exec:
               command:
@@ -75,6 +57,8 @@ spec:
             periodSeconds: 1
           resources: {}
           volumeMounts:
+          - mountPath: /dev/fuse
+            name: dev-fuse
           - mountPath: /run/secrets/certs
             name: certs
             readOnly: true
@@ -85,9 +69,9 @@ spec:
             name: calibration-auth
             readOnly: true
             subPath: calibration.auth
-          - mountPath: /home/scenescape/SceneScape/media
+          - mountPath: /workspace/media
             name: media-storage
-          - mountPath: /home/scenescape/SceneScape/datasets
+          - mountPath: /workspace/datasets
             name: datasets-storage
       restartPolicy: Always
       {{- with .Values.imagePullSecrets }}
@@ -95,6 +79,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      - name: dev-fuse
+        hostPath:
+          path: /dev/fuse
       - name: certs
         secret:
           secretName: {{ .Release.Name }}-certs

--- a/sample_data/docker-compose-dl-streamer-example.yml
+++ b/sample_data/docker-compose-dl-streamer-example.yml
@@ -334,40 +334,30 @@ services:
         target: certs/scenescape-ca.pem
     pids_limit: 1000
 
-  # Init container to fix volume permissions for camcalibration
-  camcalibration-init:
-    image: alpine:latest
-    command: sh -c "chown -R 1000:1000 /data/netvlad_models /data/media /data/datasets"
-    volumes:
-      - vol-netvlad_models:/data/netvlad_models
-      - vol-media:/data/media
-      - vol-datasets:/data/datasets
-    restart: "no"
-
   camcalibration:
-    image: scenescape-camcalibration:${VERSION:-latest}
+    image: scenescape-camcalibration
     init: true
     networks:
       scenescape:
-    user: "${UID:-1000}:${GID:-1000}"
-    command: >
-      --restauth /run/secrets/calibration.auth
-      --resturl https://web.scenescape.intel.com:443/api/v1
-      --brokerauth /run/secrets/calibration.auth
-      --broker broker.scenescape.intel.com
+    command: camcalibration --broker broker.scenescape.intel.com --resturl https://web.scenescape.intel.com:443/api/v1
     depends_on:
-      camcalibration-init:
-        condition: service_completed_successfully
       web:
         condition: service_healthy
       broker:
         condition: service_started
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    security_opt:
+      - apparmor:unconfined
     environment:
       - EGL_PLATFORM=surfaceless
+      - "DBROOT"
       - NETVLAD_MODEL_DIR=/usr/local/lib/python3.10/dist-packages/third_party/netvlad
     volumes:
-      - vol-media:/home/scenescape/SceneScape/media
-      - vol-datasets:/home/scenescape/SceneScape/datasets
+      - vol-media:/workspace/media
+      - vol-datasets:/workspace/datasets
       - vol-netvlad_models:/usr/local/lib/python3.10/dist-packages/third_party/netvlad
     secrets:
       - source: root-cert

--- a/sample_data/docker-compose-dls-perf.yml
+++ b/sample_data/docker-compose-dls-perf.yml
@@ -232,40 +232,30 @@ services:
         target: certs/scenescape-ca.pem
     tty: true
 
-  # Init container to fix volume permissions for camcalibration
-  camcalibration-init:
-    image: alpine:latest
-    command: sh -c "chown -R 1000:1000 /data/netvlad_models /data/media /data/datasets"
-    volumes:
-      - vol-netvlad_models:/data/netvlad_models
-      - vol-media:/data/media
-      - vol-datasets:/data/datasets
-    restart: "no"
-
   camcalibration:
-    image: scenescape-camcalibration:${VERSION:-latest}
+    image: scenescape-camcalibration
     init: true
     networks:
       scenescape:
-    user: "${UID:-1000}:${GID:-1000}"
-    command: >
-      --restauth /run/secrets/calibration.auth
-      --resturl https://web.scenescape.intel.com:443/api/v1
-      --brokerauth /run/secrets/calibration.auth
-      --broker broker.scenescape.intel.com
+    command: camcalibration --broker broker.scenescape.intel.com --resturl https://web.scenescape.intel.com:443/api/v1
     depends_on:
-      camcalibration-init:
-        condition: service_completed_successfully
       web:
         condition: service_healthy
       broker:
         condition: service_started
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    security_opt:
+      - apparmor:unconfined
     environment:
       - EGL_PLATFORM=surfaceless
+      - "DBROOT"
       - NETVLAD_MODEL_DIR=/usr/local/lib/python3.10/dist-packages/third_party/netvlad
     volumes:
-      - vol-media:/home/scenescape/SceneScape/media
-      - vol-datasets:/home/scenescape/SceneScape/datasets
+      - vol-media:/workspace/media
+      - vol-datasets:/workspace/datasets
       - vol-netvlad_models:/usr/local/lib/python3.10/dist-packages/third_party/netvlad
     secrets:
       - source: root-cert
@@ -273,7 +263,6 @@ services:
       - django
       - calibration.auth
     restart: always
-    pids_limit: 1000
 
 volumes:
   vol-db:

--- a/tests/compose/camcalibration.yml
+++ b/tests/compose/camcalibration.yml
@@ -13,45 +13,35 @@ secrets:
     file: ${SECRETSDIR}/calibration.auth
 
 services:
-  # Init container to fix volume permissions for camcalibration
-  camcalibration-init:
-    image: alpine:3.19
-    command: sh -c "chown -R 1000:1000 /data/netvlad_models /data/media /data/datasets"
-    volumes:
-      - vol-netvlad_models:/data/netvlad_models
-      - vol-media:/data/media
-      - vol-datasets:/data/datasets
-    restart: "no"
-
   camcalibration:
-    image: scenescape-camcalibration:${VERSION:-latest}
+    image: scenescape-camcalibration
     init: true
     networks:
       scenescape-test:
-    user: "1000:1000"
     depends_on:
-      camcalibration-init:
-        condition: service_completed_successfully
       web:
         condition: service_healthy
       broker:
         condition: service_started
-    command: >
-      --restauth /run/secrets/calibration.auth
-      --resturl https://web.scenescape.intel.com:443/api/v1
-      --brokerauth /run/secrets/calibration.auth
-      --broker broker.scenescape.intel.com
+    command: camcalibration --broker broker.scenescape.intel.com --resturl https://web.scenescape.intel.com:443/api/v1
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    security_opt:
+      - apparmor:unconfined
     environment:
       - EGL_PLATFORM=surfaceless
+      - "DBROOT"
       - NETVLAD_MODEL_DIR=/usr/local/lib/python3.10/dist-packages/third_party/netvlad
       - "http_proxy"
       - "https_proxy"
       - "no_proxy"
     volumes:
       - ./:/workspace
-      - vol-media:/home/scenescape/SceneScape/media
+      - vol-media:/workspace/${DBROOT}/media
       - vol-sample-data:/workspace/media
-      - vol-datasets:/home/scenescape/SceneScape/datasets
+      - vol-datasets:/workspace/datasets
       - vol-netvlad_models:/usr/local/lib/python3.10/dist-packages/third_party/netvlad
     secrets:
       - source: root-cert
@@ -59,10 +49,8 @@ services:
       - django
       - calibration.auth
     restart: always
-    pids_limit: 1000
 
 volumes:
-  vol-media:
   vol-datasets:
   vol-netvlad_models:
     driver: local


### PR DESCRIPTION
Reverts open-edge-platform/scenescape#492

This PR causes Autocalibration service constantly re-starting due to following error:

```
camcalibration-1  | INFO:__main__:NetVLAD On-Demand Model Loader
camcalibration-1  | INFO:__main__:NetVLAD model not found. Starting download...
camcalibration-1  | INFO:__main__:Downloading NetVLAD model from https://cvg-data.inf.ethz.ch/hloc/netvlad/Pitts30K_struct.mat
camcalibration-1  | ERROR:__main__:Unexpected error during download: [Errno 13] Permission denied: '/usr/local/lib/python3.10/dist-packages/third_party/netvlad/VGG16-NetVLAD-Pitts30K.mat'
camcalibration-1  | ERROR:__main__:Failed to download NetVLAD model
camcalibration-1  | ERROR:__main__:Failed to ensure model exists
```

Revert PR tested manually:

```
docker compose logs camcalibration 
camcalibration-1  | Checking NetVLAD model...
camcalibration-1  | INFO:__main__:NetVLAD On-Demand Model Loader
camcalibration-1  | INFO:__main__:NetVLAD model not found. Starting download...
camcalibration-1  | INFO:__main__:Downloading NetVLAD model from https://cvg-data.inf.ethz.ch/hloc/netvlad/Pitts30K_struct.mat
DownloadinINFO:__main__:Download complete: /usr/local/lib/python3.10/dist-packages/third_party/netvlad/VGG16-NetVLAD-Pitts30K.mat
camcalibration-1  | INFO:__main__:Model integrity check passed: a67d9d897d3b7942f206478e3a22a4c4c9653172ae2447041d35f6cb278fdc67
camcalibration-1  | INFO:__main__:NetVLAD model is ready for use
Downloading: 100.0% (554551295/554551295 bytes)95 bytes)
camcalibration-1  | TIMEZONE IS
camcalibration-1  | Starting auto camera calibration service
camcalibration-1  | Took 0 seconds
camcalibration-1  | Container is ready
```