### PR TITLE
ITEP-81833 Safe handling of name length limitations in `kubeclient`

### DIFF
--- a/manager/src/django/kubeclient.py
+++ b/manager/src/django/kubeclient.py
@@ -338,9 +338,9 @@ class KubeClient():
       sensor_id = msg['sensor_id']
 
     if container:
-      return f"{self.PIPELINE_SERVER_NAME[:16]}-{self.k8sName(name)}-{self.k8sName(sensor_id)}"
+      return f"{self.PIPELINE_SERVER_NAME[:8]}-{self.k8sName(name)}-{self.k8sName(sensor_id)}"
     else:
-      return f"{release}-{self.PIPELINE_SERVER_NAME[:16]}-{self.k8sName(sensor_id)}-{self.hash(sensor_id, 5)}"
+      return f"{release}-{self.PIPELINE_SERVER_NAME[:8]}-{self.k8sName(sensor_id)}-{self.hash(sensor_id, 5)}"
 
   def hash(self, input, truncate=None):
     """! Function to generate a SHA1 hash of a string, optional truncation


### PR DESCRIPTION
## 📝 Description

This PR implements:
- safe handling of name length limitations for Kubernetes resources (deployment name, container name and labels)
- more intuitive naming of pipeline server resources with the following schema (the values in `<>` are normalized and truncated):
  - deployment: `<release-name>-videoppl-<sensor_id>-<sensor-id-hash>` with maximal length 52
  - container: `videoppl-<camera-name>-<sensor_id>` with maximal length 42

The deployment names for different cameras are guaranteed to be unique because a hash of sensor ID is always added to its name (and sensor ID is unique).

This PR fixes also bugs related to `kubeclient` crashes caused by too long name / ID of camera provided by the user.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
