### PR TITLE
Always set the ownership of the models Docker volume in `install-models` make target

### DIFF
--- a/model_installer/Makefile
+++ b/model_installer/Makefile
@@ -12,14 +12,12 @@ create-models-volume:
 	@echo "Checking if models volume exists..." \
 	; COMPOSE_PROJECT_NAME=$${COMPOSE_PROJECT_NAME:-scenescape} \
 	; if docker volume inspect $${COMPOSE_PROJECT_NAME}_vol-models >/dev/null 2>&1; then \
-		echo "Volume $${COMPOSE_PROJECT_NAME}_vol-models already exists."; \
-		echo "Setting up volume permissions..."; \
-		docker run --rm -v $${COMPOSE_PROJECT_NAME}_vol-models:/dest alpine:3.23 chown -R $(shell id -u):$(shell id -g) /dest; \
-		exit 0; \
-	fi \
-	; echo "Creating models volume..." \
-	; cd .. \
-	; docker volume create $${COMPOSE_PROJECT_NAME}_vol-models \
+		echo "Volume $${COMPOSE_PROJECT_NAME}_vol-models already exists." \
+	; else \
+		echo "Creating models volume..." \
+		; cd .. \
+		; docker volume create $${COMPOSE_PROJECT_NAME}_vol-models \
+	; fi \
 	; echo "Setting up volume permissions..." \
 	; docker run --rm -v $${COMPOSE_PROJECT_NAME}_vol-models:/dest alpine:3.23 chown -R $(shell id -u):$(shell id -g) /dest
 


### PR DESCRIPTION
## 📝 Description

Fixes permission error when model_installer docker container is accessing existing models volume created with conflicting ownership / permissions. This improves developer experience, since it can happen when multiple SceneScape repositories are actively used in parallel on the same system.

### How the fix is implemented

The ownership of files in the Docker `vol-models` volume is always set recursively, not only on the volume creation, as it was before. So, the command `make build` will always result in models ownership set to current user and group ID, as it is expected. As a consequence, installing models from multiple SceneScape repositories / user accounts on the same host does not result in permission error.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
