### PR TITLE
ITEP-86988 Force cleanup before tests on main and release branches

### DIFF
--- a/.github/workflows/tests-all.yml
+++ b/.github/workflows/tests-all.yml
@@ -65,7 +65,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: "Remove all Docker images"
-        if: ${{ github.event.inputs.cleanup == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.cleanup == 'true' }}
         uses: ./.github/actions/cleanup
         with:
           system-prune: "true"
@@ -103,7 +103,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: "Remove all Docker images"
-        if: ${{ github.event.inputs.cleanup == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.cleanup == 'true' }}
         uses: ./.github/actions/cleanup
         with:
           system-prune: "true"
@@ -141,7 +141,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: "Remove all Docker images"
-        if: ${{ github.event.inputs.cleanup == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.cleanup == 'true' }}
         uses: ./.github/actions/cleanup
         with:
           system-prune: "true"
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: "Remove all Docker images"
-        if: ${{ github.event.inputs.cleanup == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.cleanup == 'true' }}
         uses: ./.github/actions/cleanup
         with:
           system-prune: "true"
@@ -217,7 +217,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: "Remove all Docker images"
-        if: ${{ github.event.inputs.cleanup == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.cleanup == 'true' }}
         uses: ./.github/actions/cleanup
         with:
           system-prune: "true"
@@ -255,7 +255,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: "Remove all Docker images"
-        if: ${{ github.event.inputs.cleanup == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.cleanup == 'true' }}
         uses: ./.github/actions/cleanup
         with:
           system-prune: "true"


### PR DESCRIPTION
## 📝 Description

Current cleanup condition was always being ewvaluated as false for pushes to main and release branches.
This caused All Tests suite to work with cached images causing it to give unexpected results.
This change changes the logic to always clean up on pushes, and use input for workflow calls and dispatches

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
