### PR TITLE
fix(controller): preserve UUID for static objects after occlusion (#1152)

### DIFF
--- a/controller/src/controller/ilabs_tracking.py
+++ b/controller/src/controller/ilabs_tracking.py
@@ -130,7 +130,8 @@ class IntelLabsTracking(Tracking):
         break
     if not found:
       # Check if UUID manager already has a mapping for this rv_id
-      existing_gid = self.uuid_manager.active_ids.get(sscape_object.rv_id, [None])[0]
+      with self.uuid_manager.active_ids_lock:
+        existing_gid = self.uuid_manager.active_ids.get(sscape_object.rv_id, [None])[0]
       if existing_gid is None:
         sscape_object.setGID(uuid)
       else:
@@ -181,11 +182,12 @@ class IntelLabsTracking(Tracking):
     """Create reliable tracks for objects detected and tracks detected"""
     when = datetime.fromtimestamp(when)
     self.update_tracks(objects, when)
+    reliable_tracks = self.tracker.get_reliable_tracks()
     # Include ALL active C++ tracks to preserve UUID mappings
-    all_active_tracks = (self.tracker.get_reliable_tracks() + 
-                        self.tracker.get_unreliable_tracks() + 
-                        self.tracker.get_suspended_tracks())
-    tracked_objects = self.tracker.get_reliable_tracks()
+    all_active_tracks = set(reliable_tracks +
+                            self.tracker.get_unreliable_tracks() +
+                            self.tracker.get_suspended_tracks())
+    tracked_objects = reliable_tracks
     self.uuid_manager.pruneInactiveTracks(all_active_tracks)
     tracks_from_detections = [self.from_tracked_object(tracked_object, objects)
                      for tracked_object in tracked_objects]
@@ -199,11 +201,12 @@ class IntelLabsTracking(Tracking):
     """Create reliable tracks for objects from multiple cameras using batched tracking"""
     when = datetime.fromtimestamp(when)
     self.update_tracks_batched(objects_per_camera, when)
+    reliable_tracks = self.tracker.get_reliable_tracks()
     # Include ALL active C++ tracks to preserve UUID mappings
-    all_active_tracks = (self.tracker.get_reliable_tracks() + 
-                        self.tracker.get_unreliable_tracks() + 
-                        self.tracker.get_suspended_tracks())
-    tracked_objects = self.tracker.get_reliable_tracks()
+    all_active_tracks = set(reliable_tracks +
+                            self.tracker.get_unreliable_tracks() +
+                            self.tracker.get_suspended_tracks())
+    tracked_objects = reliable_tracks
     self.uuid_manager.pruneInactiveTracks(all_active_tracks)
 
     # Flatten all objects for from_tracked_object lookup

--- a/controller/src/controller/ilabs_tracking.py
+++ b/controller/src/controller/ilabs_tracking.py
@@ -132,9 +132,9 @@ class IntelLabsTracking(Tracking):
       # Check if UUID manager already has a mapping for this rv_id
       existing_gid = self.uuid_manager.active_ids.get(sscape_object.rv_id, [None])[0]
       if existing_gid is None:
-          sscape_object.setGID(uuid)
+        sscape_object.setGID(uuid)
       else:
-          sscape_object.setGID(existing_gid)
+        sscape_object.setGID(existing_gid)
 
     self.uuid_manager.assignID(sscape_object)
 

--- a/controller/src/controller/ilabs_tracking.py
+++ b/controller/src/controller/ilabs_tracking.py
@@ -129,7 +129,12 @@ class IntelLabsTracking(Tracking):
         sscape_object.inferRotationFromVelocity()
         break
     if not found:
-      sscape_object.setGID(uuid)
+      # Check if UUID manager already has a mapping for this rv_id
+      existing_gid = self.uuid_manager.active_ids.get(sscape_object.rv_id, [None])[0]
+      if existing_gid is None:
+          sscape_object.setGID(uuid)
+      else:
+          sscape_object.setGID(existing_gid)
 
     self.uuid_manager.assignID(sscape_object)
 
@@ -176,8 +181,12 @@ class IntelLabsTracking(Tracking):
     """Create reliable tracks for objects detected and tracks detected"""
     when = datetime.fromtimestamp(when)
     self.update_tracks(objects, when)
+    # Include ALL active C++ tracks to preserve UUID mappings
+    all_active_tracks = (self.tracker.get_reliable_tracks() + 
+                        self.tracker.get_unreliable_tracks() + 
+                        self.tracker.get_suspended_tracks())
     tracked_objects = self.tracker.get_reliable_tracks()
-    self.uuid_manager.pruneInactiveTracks(tracked_objects)
+    self.uuid_manager.pruneInactiveTracks(all_active_tracks)
     tracks_from_detections = [self.from_tracked_object(tracked_object, objects)
                      for tracked_object in tracked_objects]
 
@@ -190,8 +199,12 @@ class IntelLabsTracking(Tracking):
     """Create reliable tracks for objects from multiple cameras using batched tracking"""
     when = datetime.fromtimestamp(when)
     self.update_tracks_batched(objects_per_camera, when)
+    # Include ALL active C++ tracks to preserve UUID mappings
+    all_active_tracks = (self.tracker.get_reliable_tracks() + 
+                        self.tracker.get_unreliable_tracks() + 
+                        self.tracker.get_suspended_tracks())
     tracked_objects = self.tracker.get_reliable_tracks()
-    self.uuid_manager.pruneInactiveTracks(tracked_objects)
+    self.uuid_manager.pruneInactiveTracks(all_active_tracks)
 
     # Flatten all objects for from_tracked_object lookup
     all_objects = [obj for camera_objects in objects_per_camera for obj in camera_objects]

--- a/controller/src/controller/uuid_manager.py
+++ b/controller/src/controller/uuid_manager.py
@@ -291,10 +291,10 @@ class UUIDManager:
           self.active_query[sscape_object.rv_id] = True
           self.pool.submit(self.querySimilarity, sscape_object)
       else:
-         # Re-ID is disabled or we don't have enough features; fall back to using the generated GID
-         with self.active_ids_lock:
-           if self.active_ids.get(sscape_object.rv_id, [None])[0] is None:
-             self.active_ids[sscape_object.rv_id] = [sscape_object.gid, None]    
+        # Re-ID is disabled or we don't have enough features; fall back to using the generated GID
+        with self.active_ids_lock:
+          if self.active_ids.get(sscape_object.rv_id, [None])[0] is None:
+            self.active_ids[sscape_object.rv_id] = [sscape_object.gid, None]
     else:
       self.pickBestID(sscape_object)
     return

--- a/controller/src/controller/uuid_manager.py
+++ b/controller/src/controller/uuid_manager.py
@@ -46,7 +46,7 @@ class UUIDManager:
 
     @param  tracked_objects  The objects currently tracked by the tracker
     """
-    active_tracks = [tracked_object.id for tracked_object in tracked_objects]
+    active_tracks = {tracked_object.id for tracked_object in tracked_objects}
     inactive_tracks = []
     new_active_ids = {}
     with self.active_ids_lock:
@@ -285,15 +285,16 @@ class UUIDManager:
         self.active_ids.setdefault(sscape_object.rv_id, [None, None])
       self.gatherQualityVisualFeatures(sscape_object)
       self.pickBestID(sscape_object)
-      # Store the assigned UUID in active_ids
-      with self.active_ids_lock:
-        if self.active_ids.get(sscape_object.rv_id, [None])[0] is None:
-          self.active_ids[sscape_object.rv_id] = [sscape_object.gid, None]
       if self.haveSufficientVisualFeatures(sscape_object) and self.reid_enabled:
         # Only do the query for similarity if it hasn't been run before
         if sscape_object.rv_id not in self.active_query:
           self.active_query[sscape_object.rv_id] = True
           self.pool.submit(self.querySimilarity, sscape_object)
+      else:
+         # Re-ID is disabled or we don't have enough features; fall back to using the generated GID
+         with self.active_ids_lock:
+           if self.active_ids.get(sscape_object.rv_id, [None])[0] is None:
+             self.active_ids[sscape_object.rv_id] = [sscape_object.gid, None]    
     else:
       self.pickBestID(sscape_object)
     return

--- a/controller/src/controller/uuid_manager.py
+++ b/controller/src/controller/uuid_manager.py
@@ -285,6 +285,10 @@ class UUIDManager:
         self.active_ids.setdefault(sscape_object.rv_id, [None, None])
       self.gatherQualityVisualFeatures(sscape_object)
       self.pickBestID(sscape_object)
+      # Store the assigned UUID in active_ids
+      with self.active_ids_lock:
+        if self.active_ids.get(sscape_object.rv_id, [None])[0] is None:
+          self.active_ids[sscape_object.rv_id] = [sscape_object.gid, None]
       if self.haveSufficientVisualFeatures(sscape_object) and self.reid_enabled:
         # Only do the query for similarity if it hasn't been run before
         if sscape_object.rv_id not in self.active_query:

--- a/controller/src/robot_vision/include/rv/tracking/MultipleObjectTracker.hpp
+++ b/controller/src/robot_vision/include/rv/tracking/MultipleObjectTracker.hpp
@@ -82,6 +82,16 @@ public:
     return mTrackManager.getReliableTracks();
   }
 
+  inline std::vector<TrackedObject> getSuspendedTracks()
+  {
+    return mTrackManager.getSuspendedTracks();
+  }
+
+  inline std::vector<TrackedObject> getUnreliableTracks()
+  {
+    return mTrackManager.getUnreliableTracks();
+  }
+
   /**
    * @brief Returns a the list of all active tracked objects
    *

--- a/controller/src/robot_vision/python/src/robot_vision/extensions/tracking.cpp
+++ b/controller/src/robot_vision/python/src/robot_vision/extensions/tracking.cpp
@@ -325,6 +325,12 @@ py::class_<rv::tracking::Classification>(tracking, "Classification", "Classifica
     .def("get_reliable_tracks",
          &rv::tracking::MultipleObjectTracker::getReliableTracks,
          "Returns a list of all active reliable tracks.")
+    .def("get_suspended_tracks",
+         &rv::tracking::MultipleObjectTracker::getSuspendedTracks,
+         "Returns a list of all suspended tracks.")
+    .def("get_unreliable_tracks",
+         &rv::tracking::MultipleObjectTracker::getUnreliableTracks,
+         "Returns a list of all active unreliable tracks.")
     .def("update_tracker_params",
          &rv::tracking::MultipleObjectTracker::updateTrackerParams,
          "Updates tracker frame based parameters.");


### PR DESCRIPTION
## 📝 Description

When a static object becomes temporarily occluded and later reappears in the scene, the controller assigns a **new UUID** instead of preserving the original one. This breaks object identity continuity for static objects across short occlusions.

This change updates the controller logic to ensure that **static objects retain their original UUID when reactivated from suspended tracks**.

Fixes #1152


## 🔍 Behavior Before / After

**Before**
- When a static object became occluded and later reappeared, the controller generated a **new UUID**.
- This caused loss of object identity across short occlusions.

**After**
- When the object reappears after occlusion, the controller **preserves the original UUID** from the suspended track.
- Object identity remains consistent across occlusion events.


## ✨ Type of Change

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**


## 🧪 Testing Scenarios

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

Tested locally by simulating occlusion scenarios where static objects temporarily disappear and later reappear. Verified that the original UUID is preserved when the object is reactivated.


## ✅ Checklist

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number in the PR title
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works