### PR TITLE
fix: prevent adding cameras with invalid model names (#1162)

### DIFF
--- a/manager/src/django/forms.py
+++ b/manager/src/django/forms.py
@@ -191,7 +191,7 @@ class CamCreateForm(forms.ModelForm):
     camerachain = self.cleaned_data.get('camerachain', '').strip()
     if not camerachain:
       return camerachain
-    
+
     from pathlib import Path
     from manager.ppl_generator.model_chain import parse_model_chain
     from manager.ppl_generator import PipelineGenerationValueError, PipelineGenerationNotImplementedError
@@ -211,7 +211,7 @@ class CamCreateForm(forms.ModelForm):
       parse_model_chain(camerachain, settings.MODEL_ROOT, model_config)
     except (PipelineGenerationValueError, PipelineGenerationNotImplementedError) as e:
       raise ValidationError(str(e))
-    
+
     return camerachain
 
 class ChildSceneForm(forms.ModelForm):

--- a/manager/src/django/forms.py
+++ b/manager/src/django/forms.py
@@ -196,7 +196,8 @@ class CamCreateForm(forms.ModelForm):
     from manager.ppl_generator.model_chain import parse_model_chain
     from manager.ppl_generator import PipelineGenerationValueError, PipelineGenerationNotImplementedError
 
-    model_config_path = Path(os.environ.get('MODEL_CONFIGS_FOLDER', '/models/model_configs')) / 'model_config.json'
+    modelconfig_name = getattr(self.instance, 'modelconfig', None) or 'model_config.json'
+    model_config_path = Path(os.environ.get('MODEL_CONFIGS_FOLDER', '/models/model_configs')) / modelconfig_name
     if not model_config_path.is_file():
       raise ValidationError(f"Model config file not found at {model_config_path}")
 

--- a/manager/src/django/forms.py
+++ b/manager/src/django/forms.py
@@ -186,6 +186,39 @@ class CamCreateForm(forms.ModelForm):
     super().__init__(*args, **kwargs)
     self.fields['scene'].required = False
 
+  # Added validation to ensure all models in camerachain exist in model_config
+  def clean_camerachain(self):
+    camerachain = self.cleaned_data.get('camerachain', '').strip()
+    if not camerachain:
+        return camerachain
+    
+    from pathlib import Path
+    from manager.ppl_generator.model_chain import CameraChainOperations
+    
+    # Load model config
+    model_config_path = Path(os.environ.get('MODEL_CONFIGS_FOLDER', '/models/model_configs')) / 'model_config.json'
+    if not model_config_path.is_file():
+        raise ValidationError(f"Model config file not found at {model_config_path}")
+    
+    try:
+        with open(model_config_path, 'r') as f:
+            model_config = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        raise ValidationError(f"Error reading model config: {str(e)}")
+    
+    # Extract model names from chain
+    chain_parts = camerachain.replace(CameraChainOperations.PARALLEL.value, CameraChainOperations.SEQUENTIAL.value)
+    model_names = [part.split('=')[0].strip() for part in chain_parts.split(CameraChainOperations.SEQUENTIAL.value) if part.strip()]
+    
+    # Validate models exist
+    missing = [m for m in model_names if m not in model_config]
+    if missing:
+        missing_str = ', '.join(f"'{m}'" for m in missing)
+        available = ', '.join(f"'{m}'" for m in sorted(model_config.keys()))
+        raise ValidationError(f"Error adding camera: Model(s) {missing_str} not found in model config file. Available models: {available}")
+    
+    return camerachain     
+
 class ChildSceneForm(forms.ModelForm):
   class Meta:
     model = ChildScene

--- a/manager/src/django/forms.py
+++ b/manager/src/django/forms.py
@@ -190,34 +190,28 @@ class CamCreateForm(forms.ModelForm):
   def clean_camerachain(self):
     camerachain = self.cleaned_data.get('camerachain', '').strip()
     if not camerachain:
-        return camerachain
+      return camerachain
     
     from pathlib import Path
-    from manager.ppl_generator.model_chain import CameraChainOperations
-    
-    # Load model config
+    from manager.ppl_generator.model_chain import parse_model_chain
+    from manager.ppl_generator import PipelineGenerationValueError, PipelineGenerationNotImplementedError
+
     model_config_path = Path(os.environ.get('MODEL_CONFIGS_FOLDER', '/models/model_configs')) / 'model_config.json'
     if not model_config_path.is_file():
-        raise ValidationError(f"Model config file not found at {model_config_path}")
-    
+      raise ValidationError(f"Model config file not found at {model_config_path}")
+
     try:
-        with open(model_config_path, 'r') as f:
-            model_config = json.load(f)
+      with open(model_config_path, 'r') as f:
+        model_config = json.load(f)
     except (json.JSONDecodeError, IOError) as e:
-        raise ValidationError(f"Error reading model config: {str(e)}")
+      raise ValidationError(f"Error reading model config: {str(e)}")
+
+    try:
+      parse_model_chain(camerachain, settings.MODEL_ROOT, model_config)
+    except (PipelineGenerationValueError, PipelineGenerationNotImplementedError) as e:
+      raise ValidationError(str(e))
     
-    # Extract model names from chain
-    chain_parts = camerachain.replace(CameraChainOperations.PARALLEL.value, CameraChainOperations.SEQUENTIAL.value)
-    model_names = [part.split('=')[0].strip() for part in chain_parts.split(CameraChainOperations.SEQUENTIAL.value) if part.strip()]
-    
-    # Validate models exist
-    missing = [m for m in model_names if m not in model_config]
-    if missing:
-        missing_str = ', '.join(f"'{m}'" for m in missing)
-        available = ', '.join(f"'{m}'" for m in sorted(model_config.keys()))
-        raise ValidationError(f"Error adding camera: Model(s) {missing_str} not found in model config file. Available models: {available}")
-    
-    return camerachain     
+    return camerachain
 
 class ChildSceneForm(forms.ModelForm):
   class Meta:

--- a/manager/src/django/views.py
+++ b/manager/src/django/views.py
@@ -266,6 +266,10 @@ class CamCreateView(SuperUserCheck, CreateView):
     form.instance.type = 'camera'
     return super(CamCreateView, self).form_valid(form)
 
+  # Return 400 Bad Request when form validation fails
+  def form_invalid(self, form):
+    return self.render_to_response(self.get_context_data(form=form), status=400)  
+
   def get_success_url(self):
     if self.object.scene is not None:
       scene_id = self.object.scene.id

--- a/manager/src/django/views.py
+++ b/manager/src/django/views.py
@@ -268,7 +268,7 @@ class CamCreateView(SuperUserCheck, CreateView):
 
   # Return 400 Bad Request when form validation fails
   def form_invalid(self, form):
-    return self.render_to_response(self.get_context_data(form=form), status=400)  
+    return self.render_to_response(self.get_context_data(form=form), status=400)
 
   def get_success_url(self):
     if self.object.scene is not None:

--- a/tests/sscape_tests/cam/test_cam_create.py
+++ b/tests/sscape_tests/cam/test_cam_create.py
@@ -17,4 +17,4 @@ class CamCreateTestCase(TestCase):
 
   def test_cam_create_page(self):
     response = self.client.post(reverse('cam_create'), data = {'sensor_id': '100', 'name': 'test_camera', 'scene': 'test_scene'})
-    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## 📝 Description

When adding a camera, the system allowed specifying a **model name that does not exist in the configured model list (`model-config`)**. The camera would still be created successfully even though the model was invalid.

This could result in a confusing state where:
- The camera appears in the system
- No video feed is processed
- No object tracking appears on the GUI

This change introduces validation during camera creation to ensure that the provided **model name exists in `model-config`**. If the model is not found, the request is rejected with a validation error.

Fixes #1162

---

## 🔍 Behavior Before / After

**Before**
- Cameras could be created with **invalid model names** that were not present in `model-config`.
- The camera would appear in the system but **no feed or tracking would be available on the GUI**.

**After**
- The system **validates the model name** during camera creation.
- If the specified model does not exist in `model-config`, the request is rejected with an appropriate validation error.

---

## ✨ Type of Change

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

---

## 🧪 Testing Scenarios

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

Tested locally by attempting to add a camera with both **valid and invalid model names**. Verified that:
- Cameras with valid models are created successfully.
- Cameras with invalid model names are rejected with a validation error.

---

## ✅ Checklist

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number in the PR title
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works