### PR TITLE
ITEP-89518 Tracking Worker Uses NTP

### DIFF
--- a/docs/design/tracker-service.md
+++ b/docs/design/tracker-service.md
@@ -48,7 +48,6 @@ Explicitly out of scope:
 - **Dynamic re-configuration** — Config changes require restart (by design for simplicity)
 - **Object re-identification** — Track IDs reset on camera handoff (when non-overlapping) or long-term occlusion or object re-entry
 - **Historical persistence** — Tracking state lost on service restart
-- **NTP time correction** — No camera clock drift compensation
 - **Lease-based scaling** — Static scene partitioning only
 - **Multi-scene fusion** — No cross-scene track handoff
 - **Scene hierarchy** — Flat scene structure only; no parent-child scene relationships or nested regions

--- a/tracker/Agents.md
+++ b/tracker/Agents.md
@@ -57,6 +57,13 @@ All `TRACKER_*` environment variables are defined in `inc/env_vars.hpp` — insp
 4. Add env var parsing in `src/config_loader.cpp`
 5. Update design docs
 
+## NTP Time Synchronization
+
+**Two clocks, two purposes — do not mix them:**
+
+- **`ClockFn` / `system_clock`** — absolute UTC time. Use `ClockFn clock_fn_` (injected via constructor, default `makeSystemClock()`) wherever code produces or compares wall-clock timestamps: message lag checks, Kalman filter time advancement, published ISO timestamps. Never call `system_clock::now()` directly in these paths — call `clock_fn_()` so NTP adjustment flows through.
+- **`steady_clock`** — monotonic relative time. Use `steady_clock::now()` for all latency/observability measurements (`receive_time`, `parse_time`, `buffer_time`, `dispatch_time`, `transform_time`, `track_time`, `publish_time`, `chunk_time`). Never replace these with `ClockFn` — `steady_clock` is immune to NTP jumps and is the correct choice for measuring durations.
+
 ## Coverage Requirements (Enforced)
 
 The Tracker Service enforces strict test coverage thresholds via CI:

--- a/tracker/inc/time_chunk_scheduler.hpp
+++ b/tracker/inc/time_chunk_scheduler.hpp
@@ -42,7 +42,8 @@ public:
      * @param publish_callback Callback for workers to publish results
      */
     TimeChunkScheduler(TimeChunkBuffer& buffer, const SceneRegistry& registry,
-                       const TrackingConfig& config, PublishCallback publish_callback);
+                       const TrackingConfig& config, PublishCallback publish_callback,
+                       ClockFn clock_fn = makeSystemClock());
 
     /// Destructor stops scheduler and all workers
     ~TimeChunkScheduler();
@@ -124,6 +125,7 @@ private:
     const SceneRegistry& registry_;
     TrackingConfig config_;
     PublishCallback publish_callback_;
+    ClockFn clock_fn_;
 
     std::chrono::milliseconds interval_;
     std::thread scheduler_thread_;

--- a/tracker/inc/tracking_worker.hpp
+++ b/tracker/inc/tracking_worker.hpp
@@ -6,6 +6,7 @@
 #include "config_loader.hpp"
 #include "coordinate_transformer.hpp"
 #include "id_map.hpp"
+#include "time_utils.hpp"
 #include "tracking_types.hpp"
 
 #include <rv/tracking/MultipleObjectTracker.hpp>
@@ -58,7 +59,8 @@ public:
      */
     TrackingWorker(TrackingScope scope, std::string scene_name, int queue_capacity,
                    PublishCallback publish_callback, const TrackingConfig& tracking_config,
-                   const std::unordered_map<std::string, Camera>& cameras);
+                   const std::unordered_map<std::string, Camera>& cameras,
+                   ClockFn clock_fn = makeSystemClock());
 
     /// Destructor joins worker thread
     ~TrackingWorker();
@@ -174,6 +176,8 @@ private:
     mutable std::mutex queue_mutex_;
     std::condition_variable queue_cv_;
     std::deque<Chunk> queue_;
+
+    ClockFn clock_fn_;
 
     std::atomic<bool> stop_requested_{false};
     std::atomic<int> processed_count_{0};

--- a/tracker/src/main.cpp
+++ b/tracker/src/main.cpp
@@ -150,7 +150,7 @@ int main(int argc, char* argv[]) {
 
     // Initialize time chunk scheduler with workers
     auto scheduler = std::make_unique<tracker::TimeChunkScheduler>(
-        chunk_buffer, scene_registry, config.tracking, publish_callback);
+        chunk_buffer, scene_registry, config.tracking, publish_callback, clock_fn);
 
     // Initialize message handler with buffer integration
     auto message_handler = std::make_unique<tracker::MessageHandler>(

--- a/tracker/src/time_chunk_scheduler.cpp
+++ b/tracker/src/time_chunk_scheduler.cpp
@@ -12,9 +12,9 @@ namespace tracker {
 
 TimeChunkScheduler::TimeChunkScheduler(TimeChunkBuffer& buffer, const SceneRegistry& registry,
                                        const TrackingConfig& config,
-                                       PublishCallback publish_callback)
+                                       PublishCallback publish_callback, ClockFn clock_fn)
     : buffer_(buffer), registry_(registry), config_(config),
-      publish_callback_(std::move(publish_callback)) {
+      publish_callback_(std::move(publish_callback)), clock_fn_(std::move(clock_fn)) {
     // Defense-in-depth: schema and config loader validate this upstream,
     // but guard here to prevent undefined behavior if bypassed.
     if (config_.time_chunking_rate_fps <= 0) {
@@ -160,7 +160,7 @@ TrackingWorker* TimeChunkScheduler::get_or_create_worker(const TrackingScope& sc
 
     // Create new worker with tracking config and cameras
     auto worker = std::make_unique<TrackingWorker>(scope, scene_display_name, kWorkerQueueCapacity,
-                                                   publish_callback_, config_, cameras);
+                                                   publish_callback_, config_, cameras, clock_fn_);
 
     LOG_INFO("Created TrackingWorker for scope {}/{} (total workers: {}, cameras: {})",
              scope.scene_id, scope.category, workers_.size() + 1, cameras.size());

--- a/tracker/src/tracking_worker.cpp
+++ b/tracker/src/tracking_worker.cpp
@@ -54,10 +54,11 @@ rv::tracking::TrackManagerConfig build_tracker_config(const TrackingConfig& conf
 TrackingWorker::TrackingWorker(TrackingScope scope, std::string scene_name, int queue_capacity,
                                PublishCallback publish_callback,
                                const TrackingConfig& tracking_config,
-                               const std::unordered_map<std::string, Camera>& cameras)
+                               const std::unordered_map<std::string, Camera>& cameras,
+                               ClockFn clock_fn)
     : scope_(std::move(scope)), scene_name_(std::move(scene_name)), queue_capacity_(queue_capacity),
       publish_callback_(std::move(publish_callback)),
-      tracker_(build_tracker_config(tracking_config)) {
+      tracker_(build_tracker_config(tracking_config)), clock_fn_(std::move(clock_fn)) {
     // Adapt frame-rate-dependent timing parameters
     tracker_.updateTrackerParams(tracking_config.time_chunking_rate_fps);
 
@@ -157,7 +158,7 @@ void TrackingWorker::run() {
 
 void TrackingWorker::process_chunk(Chunk chunk) {
     // Compute canonical timestamp once: prefer newest batch, fall back to now.
-    auto now = std::chrono::system_clock::now();
+    auto now = clock_fn_();
     auto track_timestamp =
         chunk.camera_batches.empty() ? now : chunk.camera_batches.back().timestamp;
     std::string timestamp_iso = chunk.camera_batches.empty()


### PR DESCRIPTION
## 📝 Description

### Problem
The tracker service had NTP clock synchronization support (PR#1274) but only used it in [MessageHandler](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for lag detection. [TrackingWorker](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) continued to use unadjusted [system_clock::now()](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for Kalman filter time advancement.

### Solution
Thread [ClockFn](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (the NTP-aware clock abstraction from PR#1274) through the scheduler and worker pipeline:


1. TimeChunkScheduler accepts [ClockFn](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) parameter in constructor (defaults to [makeSystemClock()](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
2. TrackingWorker accepts [ClockFn](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) parameter in constructor (defaults to [makeSystemClock()](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
3. Scheduler passes clock to workers during creation
4. Main.cpp passes the initialized [clock_fn_](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to scheduler
5. TrackingWorker.process_chunk() calls [clock_fn_()](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [system_clock::now()](vscode-file://vscode-app/c:/Users/ltalarcz/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for fallback timestamps


### Result

All time sources in the pipeline now use the same clock reference (NTP-adjusted when configured, system clock otherwise). No breaking changes—all defaults preserve current behavior.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
