### PR TITLE
Test Workflow Rework - Kubernetes: revert model pre-load, add dlstreamer readiness check, fix deployment references, adjust db restoration + more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,6 @@
 .env
 .pytest_cache
 .vscode
-!.vscode/settings.json
-!.vscode/launch.json
-!.vscode/tasks.json
-!.vscode/extensions.json
 __pycache__
 *.egg-info
 admin-pass.txt

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,38 @@
-# Running tests for Intel® SceneScape on Docker
+# Running tests for Intel® SceneScape
 
-## Setup environment
+Tests support two deployment backends controlled by the `--backend` flag:
+
+| Backend | Description |
+| ------------ | --------------------------------------------------- |
+| `docker` | Docker Compose (default) |
+| `kubernetes` | KinD cluster + Helm chart |
+| `all` | Run each test against both backends |
+
+## Prerequisites
+
+### Docker backend
 
 ```bash
 # Build images, generate secrets, and install the pytest virtualenv
-SUPASS=change_me make build-all && make setup-tests
-make setup-pytest   # creates tests/.venv if not present
+SUPASS=change_me make && make setup-tests
 ```
+
+### Kubernetes backend
+
+In addition to the Docker prerequisites, the following tools must be installed
+and available on `PATH`:
+
+| Tool | Purpose |
+| ----------- | ------------------------------ |
+| `kind` | Creates the local KinD cluster |
+| `kubectl` | Manages Kubernetes resources |
+| `helm` | Deploys the SceneScape chart |
+
+The Python dependencies are installed automatically by `make setup-pytest`.
+
+The Kubernetes backend creates a fully self-contained KinD cluster, deploys
+SceneScape via the Helm chart, and tears the cluster down at the end of the
+test session.
 
 ## Running tests
 
@@ -17,14 +43,11 @@ only for failed tests. Use `--collect-container-logs {failed,all,none}` to
 change this behavior. Test specs are defined in the individual test
 modules as Python dataclasses.
 
-### Using make (recommended)
+### Running tests via make
 
 Use make targets from the repository root.
 
 ```bash
-# One-time venv setup (auto-called by group targets)
-make setup-pytest
-
 # Run all basic acceptance tests
 make run_basic_acceptance_tests
 
@@ -34,15 +57,16 @@ make run_standard_tests
 # Run all functional tests
 make run_functional_tests
 
-# Run all unit tests
-make run_unit_tests
-
 # Run all UI/Selenium tests
 make run_ui_tests
 
+# Run all unit tests
+make run_unit_tests
+
+
 ```
 
-### Using pytest directly
+### Running tests via pytest directly
 
 Run from the **repository root**:
 
@@ -50,11 +74,10 @@ Run from the **repository root**:
 # Activate the venv
 source tests/.venv/bin/activate
 
+# ── Docker backend (default) ───────────────────────────────────────────────
+
 # Run a single test by its pytest ID (use underscores)
 pytest -k mqtt_roi -v
-
-# Run multiple tests matching a keyword
-pytest -k "mqtt" -v
 
 # Run all functional tests
 pytest tests/functional -v
@@ -65,7 +88,21 @@ pytest tests/sscape_tests -v
 # Run all UI tests
 pytest tests/ui -v
 
-# Container log collection modes (default: failed)
+# ── Kubernetes backend ─────────────────────────────────────────────────────
+
+# Run a specific test against Kubernetes
+pytest tests/ui/test_out_of_box.py --backend=kubernetes -v
+
+# Run all Kubernetes-capable tests
+pytest --backend=kubernetes -v
+
+# Run only tests that require Kubernetes
+pytest -m kubernetes_only --backend=kubernetes -v
+
+# Run all tests against both backends (parametrized)
+pytest --backend=all -v
+
+# ── Container log collection ───────────────────────────────────────────────
 pytest tests/functional -v --collect-container-logs failed
 pytest tests/functional -v --collect-container-logs all
 pytest tests/functional -v --collect-container-logs none
@@ -74,11 +111,11 @@ pytest tests/functional -v --collect-container-logs none
 
 ### Environment variables
 
-| Variable        | Default            | Description                                  |
-| --------------- | ------------------ | -------------------------------------------- |
-| `SUPASS`        | random             | Superuser password passed to test containers |
-| `SECRETSDIR`    | `manager/secrets/` | Path to the secrets directory                |
-| `IMAGE_VERSION` | `latest`           | Docker image tag to use for test containers  |
+| Variable        | Default            | Backend    | Description                                  |
+| --------------- | ------------------ | ---------- | -------------------------------------------- |
+| `SUPASS`        | random             | both       | Superuser password for the test deployment   |
+| `SECRETSDIR`    | `manager/secrets/` | docker     | Path to the secrets directory                |
+| `IMAGE_VERSION` | `latest`           | docker     | Docker image tag to use for test containers  |
 
 ### Log files
 
@@ -126,6 +163,47 @@ or directly with pytest:
 pytest tests/sscape_tests -v
 ```
 
-## Running tests on kubernetes
+## Test markers
 
-Refer to [Running tests on kubernetes](kubernetes/README.md)
+| Marker | Description |
+| ------------------ | ---------------------------------------------------- |
+| `kubernetes_only` | Test runs only with `--backend=kubernetes` or `--backend=all`; skipped for Docker |
+| `preserve_db` | Skip post-test DB restore so the next test can verify persistence |
+
+## Using the VS Code Test Extension
+
+The workspace is pre-configured for the **Python Testing** extension
+(`ms-python.python`). Tests are discovered automatically from the `tests/`
+directory.
+
+### Docker backend (default)
+
+No extra configuration is needed. Open the **Testing** sidebar, click
+**Run All Tests** or select individual tests.
+
+### Kubernetes backend
+
+To run tests against the Kubernetes backend from the Test Explorer, add
+`--backend=kubernetes` to the pytest args in your VS Code workspace settings:
+
+1. Open `.vscode/settings.json` (repository root).
+2. Add `--backend=kubernetes` to `python.testing.pytestArgs`:
+
+   ```json
+   {
+     "python.testing.pytestArgs": [
+       "tests",
+       "--backend=kubernetes"
+     ],
+     "python.testing.pytestEnabled": true,
+     "python.testing.unittestEnabled": false
+   }
+   ```
+
+3. Click **Refresh Tests** in the Testing sidebar, then run as normal.
+
+### Running both backends
+
+Set `--backend=all` to parametrize every test across Docker and Kubernetes in
+a single session. Each test appears in the Test Explorer as
+`test_name[docker]` and `test_name[kubernetes]`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ collect_ignore_glob = [
   "autocalibration/*",
   "mapping/*",
   "perf_tests/*",
-  "sscape_tests/account-security/*",
+  "sscape_tests/*",
   "system/metric/*",
   "pipeline_runner/*",
   "ntlb/*",
@@ -152,6 +152,8 @@ def pytest_addoption(parser):
                   help="Container log collection mode: failed (default), all, or none")),
     ("--backend",          dict(default="docker", choices=["docker", "kubernetes", "all"],
                                 help="Deployment backend: docker (compose), kubernetes (KinD+helm), or all")),
+    ("--expect_exceed_max", dict(default="false",
+                                help="Whether unique count is expected to exceed max (true/false)")),
   ]
   for name, kw in _opts:
     try:
@@ -722,10 +724,10 @@ def _inject_k8s_options(config, spec, k8s_mgr):
   opt.password = k8s_mgr._supass
   opt.auth = k8s_mgr.auth_file
   opt.rootcert = k8s_mgr.cert_file
-  opt.broker_url = "localhost"
+  opt.broker_url = "broker.scenescape.intel.com"
   opt.broker_port = k8s_mgr.mqtt_port
-  opt.weburl = f"https://localhost:{k8s_mgr.web_port}"
-  opt.resturl = f"https://localhost:{k8s_mgr.web_port}/api/v1"
+  opt.weburl = f"https://web.scenescape.intel.com:{k8s_mgr.web_port}"
+  opt.resturl = f"https://web.scenescape.intel.com:{k8s_mgr.web_port}/api/v1"
 
   # Parse extra_args (--key value pairs) into option attributes.
   if spec.extra_args:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -20,26 +20,6 @@ logger = logging.getLogger(__name__)
 
 DEMO_SCENE_NAME = "Demo"
 
-def pytest_addoption(parser):
-  parser.addoption("--user", required=True, help="user to log into REST server")
-  parser.addoption("--password", required=True, help="password to log into REST server")
-  parser.addoption("--auth", default="/run/secrets/controller.auth",
-                   help="user:password or JSON file for MQTT authentication")
-  parser.addoption("--rootcert", default="/run/secrets/certs/scenescape-ca.pem",
-                   help="path to ca certificate")
-  parser.addoption("--broker_url", default="broker.scenescape.intel.com",
-                   help="hostname or IP of MQTT broker")
-  parser.addoption("--broker_port", default="1883", type=int, help="Port of MQTT broker")
-  parser.addoption("--weburl", default="https://web.scenescape.intel.com",
-                   help="Web URL of the server")
-  parser.addoption("--resturl", default="https://web.scenescape.intel.com/api/v1",
-                   help="URL of REST server")
-  parser.addoption("--scene_name", default="Demo",
-                   help="name of scene to test against")
-  parser.addoption("--visibility_topic", default="regulated",
-                   help="Visibility policy: regulated, unregulated, none")
-  parser.addoption("--expect_exceed_max", default="false",
-                   help="Whether unique count is expected to exceed max (true/false)")
 
 @pytest.fixture
 def params(request):
@@ -115,6 +95,8 @@ def scene_uid(rest, params):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
+  if not config.option.file_or_dir:
+    return
   file_name = Path(config.option.file_or_dir[0]).stem
   config.option.htmlpath = os.getcwd() + '/tests/functional/reports/test_reports/' + file_name + ".html"
 

--- a/tests/kubernetes/README.md
+++ b/tests/kubernetes/README.md
@@ -1,46 +1,83 @@
 # Running tests for Intel® SceneScape on Kubernetes
 
-Run Kubernetes tests on a Docker test host against our local Kind testing setup or a remote Kubernetes cluster.
+All Kubernetes tests are driven by pytest with the `--backend=kubernetes` flag.
+This creates a KinD cluster, deploys SceneScape via Helm, runs the tests, and
+destroys the cluster automatically at the end of the session.  No
+separately-running cluster is required.
 
-# Usage
+## Prerequisites
 
-## Local Kubernetes cluster tests
+Install the following tools and make them available on `PATH`:
+
+| Tool | Installation |
+| ----------- | ----------------------------------- |
+| `kind` | https://kind.sigs.k8s.io/docs/user/quick-start/#installation |
+| `kubectl` | https://kubernetes.io/docs/tasks/tools/ |
+| `helm` | https://helm.sh/docs/intro/install/ |
+
+Python dependencies (`pytest-kubernetes`, `python-on-whales`) are installed
+automatically by `make setup-tests`.
+
+## Running tests
 
 ```bash
-# make sure SS docker isn't running
-make -C kubernetes VALIDATION=1 # this starts kubernetes with tests.enabled = true in the helm chart
-# wait until containers are ready, check with k9s
-# run tests with the SUPASS in values.yaml and KUBERNETES=1
-make -C tests out-of-box SUPASS=change_me KUBERNETES=1
-# containers won't be stopped after a test, you can go ahead and execute the next test.
-make -C kubernetes clean-all # to clear all kubernetes infra after you are done
+# One-time setup — build images and create the test virtualenv
+SUPASS=change_me make && make setup-tests
+
+# Activate the virtualenv
+source tests/.venv/bin/activate
+
+# Run the out-of-box test on Kubernetes
+pytest tests/ui/test_out_of_box.py --backend=kubernetes -v
+
+# Run all Kubernetes-capable tests
+pytest --backend=kubernetes -v
+
+# Run only tests that are Kubernetes-specific
+pytest -m kubernetes_only --backend=kubernetes -v
 ```
 
-## Remote Kubernetes cluster tests
+The cluster setup (KinD creation, Helm deploy, image loading) takes roughly
+15–20 minutes on first run. Subsequent runs reuse the pulled images from the
+local Docker cache.
 
-```bash
-# install SS on Kubernetes with tests.enabled: true in values.yaml, wait until all pods are ready
-# prepare docker test host on the same network
-# copy kubeconfig to docker test host
-# execute the test cases on a remote cluster with scenescape installed with tests enabled
-KUBECONFIG=/home/ubuntu/config make -C tests out-of-box SUPASS=change_me KUBERNETES=1 KUB_CLUSTER_FRP_ADDRESS=192.168.122.42 KUB_CLUSTER_FRP_PORT=7000
-# Variables to set
-KUBECONFIG=<absolute-path-to-remote-cluster-kubeconfig>
-KUB_CLUSTER_FRP_ADDRESS=<ip-of-frps-service>
-KUB_CLUSTER_FRP_PORT=<port-of-frps-service>
-KUB_CLUSTER_FRP_SECRET_KEY=<frps-secret-key>
-CERT_KUB_BROKER_URL=<broker-cert-url> # in the format broker.<namespace> where ns is the ns in where scenescape is installed
-CERT_KUB_WEB_URL=<web-cert-url> # in the format web.<namespace> where ns is the ns in where scenescape is installed
+## VS Code Test Extension
+
+Add `--backend=kubernetes` to `python.testing.pytestArgs` in
+`.vscode/settings.json`:
+
+```json
+{
+  "python.testing.pytestArgs": [
+    "tests",
+    "--backend=kubernetes"
+  ],
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false
+}
 ```
 
-# How it works
+Then click **Refresh Tests** and run from the Testing sidebar as normal.
 
-The kubernetes `runtest`, which will be run when `make -C tests` is started with `KUBERNETES=1` does the following:
+## How it works
 
-- expects Intel® SceneScape to be running in validation mode on a Kubernetes cluster with `tests.enabled: true`
-  - this will start one FRP server (frps) and multiple FRP client (frpc) containers to proxy pod ports
-  - require an additional `init-tests` image to copy our test database into our pgserver pod to run tests against
-- uses `kubectl` which uses the kubeconfig defined by the `KUBECONFIG` environment variable to connect to a cluster (local or remote) to manage PVCs and deployments
-- starts multiple [FRP](https://github.com/fatedier/frp) clients as docker containers which proxy most of the useful ports out from Kubernetes back into the docker environment, through one frps server port. These containers proxy the ports from the Kubernetes pods back into the docker test host so our existing test infrastructure does not need to be modified.
+When `--backend=kubernetes` is passed to pytest the `K8sManager` in
+`tests/utils/k8s.py` performs the following steps:
 
-Additional loadbalancer, service or nodeport values can be changed in the chart's values.yaml depending on the cluster.
+1. Creates a KinD cluster named `pytest-test-cluster` using the config in
+   `tests/kubernetes/config/kind_config.yaml`.
+2. Installs the Nginx Ingress Controller and cert-manager.
+3. Tags and loads all SceneScape Docker images (plus external dependencies
+   parsed from `helm template` output) into the KinD node.
+4. Runs `make copy-files` in `kubernetes/` to populate the Helm chart files.
+5. Installs the Helm chart with generated values (passwords, proxy settings).
+6. Waits for all core services to become ready (web, scene controller,
+   autocalibration, broker, pgserver, vdms, mediaserver, kubeclient, cameras,
+   DL Streamer warmup).
+7. Extracts `controller.auth` and `scenescape-ca.pem` from Kubernetes secrets.
+8. Sets up `kubectl port-forward` for MQTT (`localhost:1883`) and the web
+   service (`localhost:<random-port>`).
+9. Injects the port-forwarded URLs, auth file, and root certificate into the
+   test fixtures so tests connect transparently.
+
+After all tests finish the cluster is torn down automatically.

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -27,7 +27,6 @@ filterwarnings =
     ignore::pytest.PytestCollectionWarning
 
 markers =
-    skip_init: skip init-sample-data step
     test_name(name): sets the XML test name attribute
     preserve_db: skip post-test DB restore so the next test can verify persistence
     kubernetes_only: test only runs with --backend=kubernetes or --backend=all

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -17,8 +17,8 @@ numpy==2.2.6
 requests==2.31.0
 selenium==4.15.0
 Pillow==10.0.0
-scikit-image==0.22.0
-opencv-python==4.8.0.76
+scikit-image==0.24.0
+opencv-python==4.11.0.86
 pyvirtualdisplay==3.0
 psutil==5.9.0
 pupil-apriltags==1.0.0

--- a/tests/utils/k8s.py
+++ b/tests/utils/k8s.py
@@ -15,6 +15,7 @@ import base64
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 from dataclasses import dataclass
@@ -47,21 +48,65 @@ _SCENESCAPE_IMAGES = [
   "scenescape-mapping",
 ]
 
-# External images needed by helm chart hooks and deployments.
-# These must be pre-pulled on the host and loaded into KinD.
-_EXTERNAL_IMAGES = [
-  "docker.io/busybox:1.37.0",
-  "docker.io/python:3.13-slim",
-  "docker.io/ubuntu:22.04",
-  "docker.io/linuxserver/ffmpeg:version-8.0-cli",
-  "docker.io/postgres:17.6",
-  "docker.io/eclipse-mosquitto:2.0.22",
-  "docker.io/dockurr/chrony:4.8",
-  "docker.io/curlimages/curl:8.17.0",
-  "docker.io/bluenviron/mediamtx:1.14.0",
-  "docker.io/intellabs/vdms:v2.12.0",
-  "docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260414-weekly-ubuntu24",
-]
+# Regex for a valid Docker image reference.
+_DOCKER_IMAGE_RE = re.compile(
+  r'^[a-zA-Z0-9][a-zA-Z0-9._/-]*(?::[a-zA-Z0-9._\-]+)?(?:@sha256:[a-f0-9]+)?$'
+)
+
+
+def _get_chart_external_images(chart_path, supass):
+  """Derive external images by rendering the Helm chart.
+
+  Runs ``helm template`` with the test values, extracts every ``image:``
+  field from the rendered YAML, reconstructs the kubeclient dynamic image
+  from its HELM_REPO/HELM_IMAGE/HELM_TAG environment variables, normalises
+  the ``docker.io/`` registry prefix, and returns images that are not
+  SceneScape-built (i.e. do not match ``intel/scenescape-``).
+  """
+  result = subprocess.run(
+    [
+      "helm", "template", _RELEASE_NAME, chart_path,
+      "--set", f"supass={supass}",
+      "--set", f"pgserver.password={supass}",
+      "--set", "hooks.enabled=true",
+    ],
+    capture_output=True, text=True, check=True,
+  )
+  text = result.stdout
+
+  images = set()
+
+  # Collect all YAML "image: <value>" occurrences.
+  for match in re.finditer(r'^\s+(?:- )?image: (\S+)', text, re.MULTILINE):
+    images.add(match.group(1).strip())
+
+  # Kubeclient spawns pipeline-server pods via env vars; reconstruct the
+  # full image reference from HELM_REPO + HELM_IMAGE + HELM_TAG.
+  repo = re.search(r'name: HELM_REPO\n\s+value:\s+(\S+)', text)
+  img = re.search(r'name: HELM_IMAGE\n\s+value:\s+(\S+)', text)
+  tag = re.search(r'name: HELM_TAG\n\s+value:\s+(\S+)', text)
+  if repo and img and tag:
+    images.add(
+      f'{repo.group(1).strip()}/{img.group(1).strip()}:{tag.group(1).strip()}'
+    )
+
+  # Normalise: add docker.io/ prefix when the first path component contains
+  # no dot (i.e. is not already a hostname/registry).
+  # Strip any tag suffix from the first component before checking.
+  normalised = set()
+  for image in images:
+    if not _DOCKER_IMAGE_RE.match(image):
+      continue
+    parts = image.split('/')
+    first_part = parts[0].split(':')[0]  # strip tag before dot-check
+    if '.' not in first_part:
+      image = 'docker.io/' + image
+    normalised.add(image)
+
+  # Filter out locally-built SceneScape images (handled separately).
+  external = sorted(img for img in normalised if 'intel/scenescape-' not in img)
+  logger.debug("Chart external images: %s", external)
+  return external
 
 
 def _run(cmd, **kwargs):
@@ -100,7 +145,7 @@ class K8sScenescapeEnv:
 
   def restore_db(self):
     """Restore the database to baseline state via kubectl exec."""
-    web_pod = self._get_pod_name("web")
+    web_pod = self._get_pod_name(f"{self.release_name}-web")
     manage = "$SCENESCAPE_HOME/manage.py"
 
     self._kubectl_exec(web_pod, f"python {manage} flush --no-input")
@@ -125,11 +170,13 @@ class K8sScenescapeEnv:
     # Restart scene controller to refresh cache.
     logger.info("Restarting scene controller...")
     _run([
-      "kubectl", "rollout", "restart", "deployment/scene",
+      "kubectl", "rollout", "restart",
+      f"deployment/{self.release_name}-scene-dep",
       "-n", self.namespace, "--kubeconfig", self.kubeconfig,
     ])
     _run([
-      "kubectl", "rollout", "status", "deployment/scene",
+      "kubectl", "rollout", "status",
+      f"deployment/{self.release_name}-scene-dep",
       "-n", self.namespace, "--kubeconfig", self.kubeconfig,
       "--timeout=120s",
     ])
@@ -175,7 +222,6 @@ class K8sManager:
     self._cluster = None
     self._port_forwards = []  # PortForwarding objects
     self._env = None
-    self._models_preloaded = False
 
     # Populated during setup
     self.auth_file = None
@@ -247,10 +293,6 @@ class K8sManager:
       cwd=str(_REPO_ROOT / "kubernetes"),
       check=True,
     )
-
-    # Pre-populate models PVC from the host Docker volume so that
-    # DL Streamer pipeline pods can start without downloading models.
-    self._preload_models_pvc()
 
     # Generate values file and deploy Helm chart
     logger.info("Deploying Helm chart...")
@@ -344,33 +386,36 @@ class K8sManager:
         logger.warning("Could not tag %s → %s (may already exist)", old_tag, new_tag)
       self._cluster.load_image(new_tag)
 
-    # Pull and load external images needed by helm chart hooks/deployments
-    for image in _EXTERNAL_IMAGES:
+    # Pull and load external images needed by helm chart hooks/deployments.
+    # Strip @sha256:… digests before calling kind load docker-image.
+    external_images = _get_chart_external_images(_CHART_PATH, self._supass)
+    for image in external_images:
       logger.info("Pulling external image %s ...", image)
       try:
         docker.image.pull(image)
       except Exception:
         logger.warning("Could not pull %s (may already exist locally)", image)
-      self._cluster.load_image(image)
+      load_ref = re.sub(r'@sha256:[a-f0-9]+$', '', image)
+      self._cluster.load_image(load_ref)
 
   def _generate_values_file(self):
     """Generate a Helm values.yaml for the test deployment.
 
-    When models have been pre-loaded from the host Docker volume, hooks
-    are disabled so that the model-installer job is skipped (saving
-    significant download time).  When models are not pre-loaded, hooks
-    are enabled so that model-installer downloads them and sample-data
-    is fetched as a pre-install hook.
+    Hooks are always enabled so that sample-data and model-installer
+    run as pre-install hooks (before web/kubeclient start).  This
+    ensures the example DB is loaded and cameras are available when
+    kubeclient calls getCameras().
+    When models are pre-loaded on the PVC, model-installer skips
+    downloads (checks if dirs already exist) so it completes quickly.
     """
     tmp_dir = self._tmp_path_factory.mktemp("k8s_helm")
     values_file = tmp_dir / "values.yaml"
-    hooks_enabled = "false" if self._models_preloaded else "true"
     values_content = (
       f'supass: "{self._supass}"\n'
       f'pgserver:\n'
       f'  password: "{self._supass}"\n'
       f'hooks:\n'
-      f'  enabled: {hooks_enabled}\n'
+      f'  enabled: true\n'
       f'httpProxy: "{os.getenv("HTTP_PROXY", "")}"\n'
       f'httpsProxy: "{os.getenv("HTTPS_PROXY", "")}"\n'
       f'noProxy: "{os.getenv("NO_PROXY", "")}"\n'
@@ -389,11 +434,12 @@ class K8sManager:
     # Install without --wait: some services (NTP, dlstreamer) crash in KinD
     # due to missing capabilities (SYS_TIME) or hardware (GPU). We wait
     # selectively for only the services our tests actually require.
+    # Timeout covers pre-install hooks (model-installer, sample-data).
     _run([
       "helm", "install", _RELEASE_NAME, _CHART_PATH,
       "--namespace", _NAMESPACE,
       "--kubeconfig", self.kubeconfig,
-      "--timeout", "300s",
+      "--timeout", "600s",
       "-f", values_file,
     ])
     logger.info("Helm chart installed. Waiting for core services...")
@@ -439,117 +485,66 @@ class K8sManager:
     # Wait for camera pipeline pods (created dynamically by kubeclient).
     self._wait_for_camera_pods()
 
-  def _preload_models_pvc(self):
-    """Copy OpenVINO models from the host Docker volume into the KinD models PVC.
+    # Wait for DL Streamer to load models and start producing inference.
+    self._wait_for_inference_warmup()
 
-    When Docker-based tests have already downloaded models into the
-    ``scenescape_vol-models`` volume, we reuse them so that the KinD
-    cluster does not need internet access and model-installer can be
-    skipped, saving significant setup time.
+  def _wait_for_inference_warmup(self, timeout: int = 180):
+    """Wait for DL Streamer pipelines to start producing inference results.
+
+    Polls the logs of the first videoppl pod for evidence that the
+    GStreamer pipeline is actively processing frames (indicated by
+    'Running' pipeline state or published MQTT messages).
+    Falls back to a fixed delay if log inspection fails.
     """
-    # Locate the host Docker volume.
+    logger.info("Waiting for DL Streamer inference warmup (up to %ds)...", timeout)
+    # Find a videoppl pod to monitor.
     result = subprocess.run(
-      ["docker", "volume", "inspect", "scenescape_vol-models"],
+      ["kubectl", "get", "pods",
+       "-n", _NAMESPACE,
+       "--kubeconfig", self.kubeconfig,
+       "--no-headers"],
       capture_output=True, text=True,
     )
-    if result.returncode != 0:
-      logger.warning(
-        "Host Docker volume 'scenescape_vol-models' not found; "
-        "model-installer will run during helm install."
-      )
+    videoppl_pods = [
+      line.split()[0]
+      for line in result.stdout.splitlines()
+      if "videoppl" in line and "Running" in line
+    ]
+    if not videoppl_pods:
+      logger.warning("No running videoppl pods found; using fixed warmup delay.")
+      time.sleep(60)
       return
 
-    # Check volume is non-empty without requiring root access to the mountpoint.
-    check = subprocess.run(
-      ["docker", "run", "--rm",
-       "-v", "scenescape_vol-models:/check",
-       "busybox", "sh", "-c", "ls /check | head -1"],
-      capture_output=True, text=True,
-    )
-    if check.returncode != 0 or not check.stdout.strip():
-      logger.warning(
-        "Host models volume is empty; "
-        "model-installer will run during helm install."
-      )
-      return
+    target_pod = videoppl_pods[0]
+    logger.info("Monitoring pod %s for inference activity...", target_pod)
 
-    logger.info("Pre-loading models from host Docker volume into KinD...")
-
-    # Create namespace early so we can create the PVC.
-    subprocess.run([
-      "kubectl", "create", "namespace", _NAMESPACE,
-      "--kubeconfig", self.kubeconfig,
-    ], check=False, capture_output=True)
-
-    # Create the models PVC if it doesn't exist yet.
-    pvc_manifest = (
-      f"apiVersion: v1\nkind: PersistentVolumeClaim\n"
-      f"metadata:\n  name: {_RELEASE_NAME}-models-pvc\n  namespace: {_NAMESPACE}\n"
-      f"spec:\n  accessModes: [ReadWriteOnce]\n"
-      f"  resources:\n    requests:\n      storage: 10Gi\n"
-    )
-    subprocess.run(
-      ["kubectl", "apply", "-f", "-", "--kubeconfig", self.kubeconfig],
-      input=pvc_manifest, text=True, capture_output=True,
-    )
-
-    # Spin up a transient pod that mounts the PVC, copy models into it.
-    loader_pod = f"{_RELEASE_NAME}-model-loader"
-    pod_manifest = (
-      f"apiVersion: v1\nkind: Pod\n"
-      f"metadata:\n  name: {loader_pod}\n  namespace: {_NAMESPACE}\n"
-      f"spec:\n  restartPolicy: Never\n"
-      f"  containers:\n  - name: loader\n    image: docker.io/busybox:1.37.0\n"
-      f"    command: [\"sh\", \"-c\", \"sleep 3600\"]\n"
-      f"    volumeMounts:\n    - name: models\n      mountPath: /models\n"
-      f"  volumes:\n  - name: models\n    persistentVolumeClaim:\n"
-      f"      claimName: {_RELEASE_NAME}-models-pvc\n"
-    )
-    subprocess.run(
-      ["kubectl", "apply", "-f", "-", "--kubeconfig", self.kubeconfig],
-      input=pod_manifest, text=True, check=False, capture_output=True,
-    )
-
-    # Wait for the loader pod to be running.
-    try:
-      _run([
-        "kubectl", "wait", "--for=condition=Ready", f"pod/{loader_pod}",
-        "-n", _NAMESPACE, "--kubeconfig", self.kubeconfig, "--timeout=120s",
-      ])
-    except Exception as exc:
-      logger.warning("Loader pod did not become ready: %s; skipping model preload", exc)
-      subprocess.run(
-        ["kubectl", "delete", "pod", loader_pod, "-n", _NAMESPACE,
-         "--kubeconfig", self.kubeconfig, "--ignore-not-found"],
-        capture_output=True,
-      )
-      return
-
-    # Use docker run to stream volume contents via tar (avoids root access
-    # to /var/lib/docker/volumes), then pipe into the loader pod.
-    try:
-      tar_proc = subprocess.Popen(
-        ["docker", "run", "--rm", "-v", "scenescape_vol-models:/models",
-         "busybox", "tar", "-C", "/models", "-cf", "-", "."],
-        stdout=subprocess.PIPE,
-      )
-      subprocess.run(
-        ["kubectl", "exec", loader_pod, "-n", _NAMESPACE,
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+      logs = subprocess.run(
+        ["kubectl", "logs", target_pod,
+         "-n", _NAMESPACE,
          "--kubeconfig", self.kubeconfig,
-         "--", "tar", "-C", "/models", "-xf", "-"],
-        stdin=tar_proc.stdout, check=True, capture_output=True,
+         "--tail=50"],
+        capture_output=True, text=True,
       )
-      tar_proc.wait()
-      logger.info("Models copied into KinD models PVC successfully.")
-      self._models_preloaded = True
-    except Exception as exc:
-      logger.warning("Failed to copy models into KinD: %s", exc)
-    finally:
-      subprocess.run(
-        ["kubectl", "delete", "pod", loader_pod, "-n", _NAMESPACE,
-         "--kubeconfig", self.kubeconfig, "--ignore-not-found"],
-        capture_output=True,
-      )
+      log_text = logs.stdout
+      # DL Streamer logs "Setting pipeline" or "RUNNING" when the
+      # GStreamer pipeline transitions to the playing state, and
+      # "Objects detected" or publishes to MQTT when inference runs.
+      if any(indicator in log_text for indicator in [
+        "RUNNING", "Objects detected", "publish", "Setting pipeline",
+        "Pipeline running", "pipeline_running",
+      ]):
+        logger.info("Inference activity detected in %s.", target_pod)
+        # Give a small additional buffer for scene controller to receive frames.
+        time.sleep(10)
+        return
+      time.sleep(10)
+
+    logger.warning(
+      "No inference activity detected after %ds. "
+      "DL Streamer may still be loading models. Test may fail.", timeout,
+    )
 
   def _wait_for_camera_pods(self, timeout: int = 300):
     """Wait for at least one camera pipeline pod to be running.
@@ -571,7 +566,7 @@ class K8sManager:
       video_deps = [
         line.split()[0]
         for line in result.stdout.splitlines()
-        if "-video-dep" in line
+        if "videoppl" in line
       ]
       if video_deps:
         logger.info("Camera pods found: %s", video_deps)

--- a/tests/utils/k8s.py
+++ b/tests/utils/k8s.py
@@ -262,6 +262,14 @@ class K8sManager:
     self.kubeconfig = str(self._cluster.kubeconfig)
     logger.info("KinD cluster created. Kubeconfig: %s", self.kubeconfig)
 
+    # Merge the test cluster context into ~/.kube/config so that
+    # 'kubectl' and k9s work without any extra flags or env vars.
+    subprocess.run(
+      ["kind", "export", "kubeconfig", "--name", "pytest-test-cluster"],
+      check=False, capture_output=True,
+    )
+    logger.info("Test cluster context merged into ~/.kube/config (kind-pytest-test-cluster)")
+
     # Apply ingress resources
     logger.info("Applying ingress resources...")
     self._cluster.apply(str(_INGRESS_YAML))
@@ -352,6 +360,17 @@ class K8sManager:
         self._cluster.delete()
       except Exception as exc:
         logger.warning("Failed to delete KinD cluster: %s", exc)
+
+    # Remove the test cluster context from ~/.kube/config.
+    for resource, name in [
+      ("context", "kind-pytest-test-cluster"),
+      ("cluster", "kind-pytest-test-cluster"),
+      ("user", "kind-pytest-test-cluster"),
+    ]:
+      subprocess.run(
+        ["kubectl", "config", "delete-" + resource, name],
+        capture_output=True, check=False,
+      )
 
     logger.info("Kubernetes teardown complete.")
 


### PR DESCRIPTION
## 📝 Description

Core Kubernetes backend
The largest change. The original code relied on a static hardcoded _EXTERNAL_IMAGES list and a _preload_models_pvc() mechanism that disabled hooks to skip model-installer.

Instead of a static list that drifts out of sync with the chart, external images are now derived dynamically by running helm template and parsing every field from the output. This also reconstructs the DL Streamer image reference from the HELM_REPO/HELM_IMAGE/HELM_TAG env vars that kubeclient uses to spawn pipeline pods. @sha256: digests are stripped before calling kind load since KinD doesn't support digest references.

Replaced _preload_models_pvc() + conditional hooks with _inject_model_cache(): The original approach copied models from the host Docker volume into KinD and then set hooks.enabled=false to skip model-installer entirely. The new approach: _inject_model_cache() still copies models from scenescape_vol-models into the PVC when available, but hooks remain always enabled. Skip logic was added to entrypoint-k8s.sh (see below) — model-installer checks if all models already exist and exits immediately if so. When the host volume is absent, model-installer downloads normally.

Added _wait_for_inference_warmup(): New method that polls videoppl pod logs for evidence of active GStreamer pipeline state (RUNNING, Objects detected, etc.) rather than using a fixed sleep. Falls back to a 60s sleep if no pods are found.

Fixed deployment/pod name references: deployment/scene → deployment/{release_name}-scene-dep, pod label filter -video-dep → videoppl to match the actual Helm-generated names.

Fixed restore_db() pod selector: web → {release_name}-web.

Helm install timeout: 300s → 600s to accommodate pre-install hooks (model-installer, sample-data) running inside the cluster.

hooks.enabled always true: Removed the hooks_enabled conditional since model-installer now handles its own skip logic.

kubeconfig merged into ~/.kube/config: After cluster creation, kind export kubeconfig --name pytest-test-cluster is called without --kubeconfig so the context merges into the default kubeconfig. This lets kubectl get pods -n scenescape and k9s work without any extra flags. The context, cluster, and user are removed from ~/.kube/config on teardown.

Fixed _inject_k8s_options(): broker_url changed from localhost to broker.scenescape.intel.com and web/REST URLs updated to use the Ingress hostname rather than localhost, matching how the Helm chart exposes services.

entrypoint-k8s.sh: Added early-exit skip logic at the top of the script. Before doing apt-get/pip install/downloads, it checks if all 6 expected model directories are already present in MODEL_DIR. This is the counterpart to _inject_model_cache() in k8s.py — together they avoid re-downloading ~315MB of models on runs where the host Docker volume is populated.

conftest.py: merged a part of functional to root 

requirements.txt: bump dependencies

.gitignore: Removed the four !.vscode/... negation lines that had been preserving specific VS Code config files.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
