### PR TITLE
ITEP-91589: Fix rest-test test [NEX-T10464]

### DIFF
--- a/manager/tests/tc_rest_test.py
+++ b/manager/tests/tc_rest_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: (C) 2022 - 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2022 - 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from tests.functional import FunctionalTest
@@ -120,6 +120,8 @@ class TestAPI(FunctionalTest):
           createData['sensor_id'] = createData['name']
         elif 'username' in createData:
           createData['username'] = createData['name']
+          if 'password' not in createData:
+            createData['password'] = 'test_password'
         elif 'marker_id' in createData:
           createData['marker_id'] = createData['name']
         if scene:


### PR DESCRIPTION
## 📝 Description

The createUser call returns an empty dict.

the fix:
for the user update test, test case data didn't include password which caused user serializer to fail the call due to password requirement. 
The fix is to add a password to createData when creating a User for the update test.


JIRA: ITEP-91589
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
