### PR TITLE
Fix: Return 404 instead of 500 when updating asset with non-integer UID

### DIFF
--- a/manager/src/manager/api.py
+++ b/manager/src/manager/api.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) 2023 - 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2023 - 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/manager/src/manager/api.py
+++ b/manager/src/manager/api.py
@@ -130,8 +130,10 @@ class ManageThing(APIView):
     if uid_field in ['sensor_id', 'username', 'marker_id']:
       return uid
 
-    if uid_field == 'pk' and uid.isdigit():
-      return int(uid)
+    if uid_field == 'pk' and thing_type not in ['scene']:
+      if uid.isdigit():
+        return int(uid)
+      return None
 
     if uid_field in ['uuid'] or thing_type in ['region', 'tripwire', 'child', 'scene']:
       try:


### PR DESCRIPTION
## 📝 Description

PR ITEP-87925: Return 404 for non-existent thing objects (https://github.com/open-edge-platform/scenescape/pull/1378) introduced a flaw which caused api to pass unchecked non-digit string to an integer-PK DB query, resulting in error 500 responses. 

Issue was that _parse_uid method allowed non-digit strings to pass through and send them to Django, which cannot cast a UUID string to an integer PK, causing a database-level ValueError that propagates as an unhandled HTTP 500.

fix:
when pk and uid is not a digit, return None (existing filters handle the expected errors)
exclude scene type as it also uses uid_field but stores a UUID as its primary key.

-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
