### PR TITLE
RC1 use dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1

### DIFF
--- a/kubernetes/scenescape-chart/values.yaml
+++ b/kubernetes/scenescape-chart/values.yaml
@@ -71,12 +71,12 @@ kubeclient:
   vaPipeline:
     repository: docker.io
     image: intel/dlstreamer-pipeline-server
-    tag: "2026.1.0-20260428-weekly-ubuntu24"
+    tag: "2026.1.0-ubuntu24-rc1"
     pullPolicy: IfNotPresent
 
 retail:
   repository: docker.io/intel/dlstreamer-pipeline-server
-  tag: "2026.1.0-20260428-weekly-ubuntu24"
+  tag: "2026.1.0-ubuntu24-rc1"
   pullPolicy: IfNotPresent
   storageClassName: ""
   cameras:
@@ -90,7 +90,7 @@ retail:
 queuing:
   repository: docker.io/intel/dlstreamer-pipeline-server
   pullPolicy: IfNotPresent
-  tag: "2026.1.0-20260428-weekly-ubuntu24"
+  tag: "2026.1.0-ubuntu24-rc1"
   storageClassName: ""
   cameras:
     image: linuxserver/ffmpeg

--- a/sample_data/docker-compose-dl-streamer-example.yml
+++ b/sample_data/docker-compose-dl-streamer-example.yml
@@ -297,7 +297,7 @@ services:
     pids_limit: 1000
 
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape:
     tty: true
@@ -361,7 +361,7 @@ services:
     pids_limit: 1000
 
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape:
     tty: true

--- a/sample_data/docker-compose-dls-perf.yml
+++ b/sample_data/docker-compose-dls-perf.yml
@@ -248,7 +248,7 @@ services:
     pids_limit: 1000
 
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     privileged: true
     networks:
       scenescape:

--- a/tests/compose/dlstreamer/queuing_video.yml
+++ b/tests/compose/dlstreamer/queuing_video.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/queuing_video_no_ntp.yml
+++ b/tests/compose/dlstreamer/queuing_video_no_ntp.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/queuing_video_reid.yml
+++ b/tests/compose/dlstreamer/queuing_video_reid.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/queuing_video_reid_semantic.yml
+++ b/tests/compose/dlstreamer/queuing_video_reid_semantic.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/retail_video.yml
+++ b/tests/compose/dlstreamer/retail_video.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/retail_video_no_ntp.yml
+++ b/tests/compose/dlstreamer/retail_video_no_ntp.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/retail_video_reid.yml
+++ b/tests/compose/dlstreamer/retail_video_reid.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       scenescape-test:
     tty: true

--- a/tests/perf_tests/compose/docker-compose-inference_performance.yml
+++ b/tests/perf_tests/compose/docker-compose-inference_performance.yml
@@ -77,7 +77,7 @@ services:
     pids_limit: 1000
 
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     privileged: true
     networks:
       scenescape-test:

--- a/tools/pipeline_runner/docker-compose-ppl.yaml
+++ b/tools/pipeline_runner/docker-compose-ppl.yaml
@@ -88,7 +88,7 @@ services:
     user: "${UID:-1000}:${GID:-1000}"
 
   video-pipeline:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-20260428-weekly-ubuntu24
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
     networks:
       ppl_runner:
     tty: true


### PR DESCRIPTION
## 📝 Description

This pull request updates all references to the `intel/dlstreamer-pipeline-server` container image to use the new release candidate tag `2026.1.0-ubuntu24-rc1` instead of the previous weekly build tag. 
**Container image version update:**

* Updated the `tag` field for `intel/dlstreamer-pipeline-server` to `2026.1.0-ubuntu24-rc1` in the following files:
  - `kubernetes/scenescape-chart/values.yaml` for `vaPipeline`, `retail`, and `queuing` services. [[1]](diffhunk://#diff-3d4dced03124970f9da21865c04cbad9a2c56a8cc357fa057e04ee9ed202e28aL74-R79) [[2]](diffhunk://#diff-3d4dced03124970f9da21865c04cbad9a2c56a8cc357fa057e04ee9ed202e28aL93-R93)
  - `sample_data/docker-compose-dl-streamer-example.yml` for `retail-video` and `queuing-video` services. [[1]](diffhunk://#diff-220a12094fbc395bd75f1d847eafc93a5621aadeff24111365a67b3fc2f73e90L300-R300) [[2]](diffhunk://#diff-220a12094fbc395bd75f1d847eafc93a5621aadeff24111365a67b3fc2f73e90L364-R364)
  - `sample_data/docker-compose-dls-perf.yml` for `retail-video`.
  - `tests/compose/dlstreamer/retail_video.yml`, `retail_video_no_ntp.yml`, `retail_video_reid.yml`, `queuing_video.yml`, `queuing_video_no_ntp.yml`, `queuing_video_reid.yml`, `queuing_video_reid_semantic.yml` for both `retail-video` and `queuing-video` services. [[1]](diffhunk://#diff-2ae38daa97133274be0c44bb63a1200a5e36d9b84d94a4050389d3c6bd722314L13-R13) [[2]](diffhunk://#diff-72d4351e94244d7e34cc7cf734ecf4bc0cc237af4f58988b87bf6b43428c6d4bL12-R12) [[3]](diffhunk://#diff-cbbf99de396b07b70c3657f3f13196944a8455b3ee8735aa3b79c00fb9d9e649L13-R13) [[4]](diffhunk://#diff-e3606c211bca45200b1d4b449fdeb4db1ad862e6b85a8316f89c82bfc434f034L13-R13) [[5]](diffhunk://#diff-944170251f864ed041aecbcc1af9da6768d722c12cb5321fe5189187364b2df8L12-R12) [[6]](diffhunk://#diff-99842468c75c0b24c51407ab02299a351e5ecbf9ef40a9d7caed001fdd37038aL13-R13) [[7]](diffhunk://#diff-4682788f01c9f47e11d93311ea7a528d3a0247317e94a7d70a604841a935a132L13-R13)
  - `tests/perf_tests/compose/docker-compose-inference_performance.yml` for `retail-video`.
  - `tools/pipeline_runner/docker-compose-ppl.yaml` for `video-pipeline`.

No other functional or structural changes were made in this pull request.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
