### PR TITLE
[DLStreamer] Update to 2026.1.0-ubuntu24-rc1.1 and fix: match dotted RC versions in DLStreamer update workflow

### DIFF
--- a/.github/workflows/update-dlstreamer.yml
+++ b/.github/workflows/update-dlstreamer.yml
@@ -40,8 +40,8 @@ jobs:
           WEEKLY_VERSION=$(echo "$LATEST_WEEKLY" | cut -d'|' -f2)
           WEEKLY_DATE=$(echo "$LATEST_WEEKLY" | cut -d'|' -f1)
 
-          # Get latest RC version (format: YYYY.X.X-ubuntu24-rcX)
-          LATEST_RC=$(echo "$ALL_TAGS" | jq -r '.results[] | select(.name | test("^[0-9]{4}\\.[0-9]+\\.[0-9]+-ubuntu24-rc[0-9]+$")) | "\(.last_updated)|\(.name)"' | sort -r | head -1)
+          # Get latest RC version (format: YYYY.X.X-ubuntu24-rcX or YYYY.X.X-ubuntu24-rcX.Y)
+          LATEST_RC=$(echo "$ALL_TAGS" | jq -r '.results[] | select(.name | test("^[0-9]{4}\\.[0-9]+\\.[0-9]+-ubuntu24-rc[0-9]+(\\.[0-9]+)*$")) | "\(.last_updated)|\(.name)"' | sort -r | head -1)
           RC_VERSION=$(echo "$LATEST_RC" | cut -d'|' -f2)
           RC_DATE=$(echo "$LATEST_RC" | cut -d'|' -f1)
 

--- a/kubernetes/scenescape-chart/values.yaml
+++ b/kubernetes/scenescape-chart/values.yaml
@@ -71,12 +71,12 @@ kubeclient:
   vaPipeline:
     repository: docker.io
     image: intel/dlstreamer-pipeline-server
-    tag: "2026.1.0-ubuntu24-rc1"
+    tag: "2026.1.0-ubuntu24-rc1.1"
     pullPolicy: IfNotPresent
 
 retail:
   repository: docker.io/intel/dlstreamer-pipeline-server
-  tag: "2026.1.0-ubuntu24-rc1"
+  tag: "2026.1.0-ubuntu24-rc1.1"
   pullPolicy: IfNotPresent
   storageClassName: ""
   cameras:
@@ -90,7 +90,7 @@ retail:
 queuing:
   repository: docker.io/intel/dlstreamer-pipeline-server
   pullPolicy: IfNotPresent
-  tag: "2026.1.0-ubuntu24-rc1"
+  tag: "2026.1.0-ubuntu24-rc1.1"
   storageClassName: ""
   cameras:
     image: linuxserver/ffmpeg

--- a/sample_data/docker-compose-dl-streamer-example.yml
+++ b/sample_data/docker-compose-dl-streamer-example.yml
@@ -297,7 +297,7 @@ services:
     pids_limit: 1000
 
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape:
     tty: true
@@ -361,7 +361,7 @@ services:
     pids_limit: 1000
 
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape:
     tty: true

--- a/sample_data/docker-compose-dls-perf.yml
+++ b/sample_data/docker-compose-dls-perf.yml
@@ -248,7 +248,7 @@ services:
     pids_limit: 1000
 
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     privileged: true
     networks:
       scenescape:

--- a/tests/compose/dlstreamer/queuing_video.yml
+++ b/tests/compose/dlstreamer/queuing_video.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/queuing_video_no_ntp.yml
+++ b/tests/compose/dlstreamer/queuing_video_no_ntp.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/queuing_video_reid.yml
+++ b/tests/compose/dlstreamer/queuing_video_reid.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/queuing_video_reid_semantic.yml
+++ b/tests/compose/dlstreamer/queuing_video_reid_semantic.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   queuing-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/retail_video.yml
+++ b/tests/compose/dlstreamer/retail_video.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/retail_video_no_ntp.yml
+++ b/tests/compose/dlstreamer/retail_video_no_ntp.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape-test:
     tty: true

--- a/tests/compose/dlstreamer/retail_video_reid.yml
+++ b/tests/compose/dlstreamer/retail_video_reid.yml
@@ -10,7 +10,7 @@ secrets:
 
 services:
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       scenescape-test:
     tty: true

--- a/tests/perf_tests/compose/docker-compose-inference_performance.yml
+++ b/tests/perf_tests/compose/docker-compose-inference_performance.yml
@@ -77,7 +77,7 @@ services:
     pids_limit: 1000
 
   retail-video:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     privileged: true
     networks:
       scenescape-test:

--- a/tools/pipeline_runner/docker-compose-ppl.yaml
+++ b/tools/pipeline_runner/docker-compose-ppl.yaml
@@ -88,7 +88,7 @@ services:
     user: "${UID:-1000}:${GID:-1000}"
 
   video-pipeline:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1.1
     networks:
       ppl_runner:
     tty: true


### PR DESCRIPTION
## 📝 Description

Update DLStreamer to 2026.1.0-ubuntu24-rc1.1
GitHub Actions fix covering RC.1.1 versioning

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
