### PR TITLE
Tracker Service — Add Footprint Offset to Projection

### DIFF
--- a/tracker/src/coordinate_transformer.cpp
+++ b/tracker/src/coordinate_transformer.cpp
@@ -184,10 +184,28 @@ CoordinateTransformer::transformDetections(std::span<const Detection> detections
         const double elevation_angle = std::atan2(std::abs(cam_z), ll1);
         const double height_m = std::sin(elevation_angle) * ll2;
 
+        // Shift foot point away from camera by half the object width along
+        // the camera→foot bearing.  This compensates for the fact that the
+        // bottom-center of the bounding box projects to the near edge of
+        // the object's footprint, not its center.  Without this offset,
+        // the same object observed from two cameras at different angles
+        // projects to two different ground points, causing duplicate tracks
+        // when the gap exceeds the matching threshold.
+        const double foot_dx = foot.x - cam_x;
+        const double foot_dy = foot.y - cam_y;
+        const double bearing_len = std::sqrt(foot_dx * foot_dx + foot_dy * foot_dy);
+        double offset_x = foot.x;
+        double offset_y = foot.y;
+        if (bearing_len > 1e-9) {
+            const double half_size = width_m / 2.0;
+            offset_x += (foot_dx / bearing_len) * half_size;
+            offset_y += (foot_dy / bearing_len) * half_size;
+        }
+
         auto& obj = result[i];
         obj.id = detections[i].id.value_or(rv::tracking::InvalidObjectId);
-        obj.x = foot.x;
-        obj.y = foot.y;
+        obj.x = offset_x;
+        obj.y = offset_y;
         obj.z = 0.0;
         obj.length = width_m; // [width, width, height] convention
         obj.width = width_m;

--- a/tracker/test/tools/generate_reference_data.py
+++ b/tracker/test/tools/generate_reference_data.py
@@ -305,6 +305,26 @@ def generate_bbox_foot_tests(intrinsics_mat, distortion, pose_mat, camera_origin
     norm_x, norm_y = map_pixel_to_normalized(foot_x, foot_y, intrinsics_mat, distortion)
     world = camera_point_to_world(norm_x, norm_y, pose_mat, camera_origin)
 
+    # Compute width_m (bottom-left to bottom-right distance) for footprint offset
+    bl = pixel_to_world_point(
+        bbox['x'], bbox['y'] + bbox['height'],
+        intrinsics_mat, distortion, pose_mat, camera_origin)
+    br = pixel_to_world_point(
+        bbox['x'] + bbox['width'], bbox['y'] + bbox['height'],
+        intrinsics_mat, distortion, pose_mat, camera_origin)
+    width_m = math.sqrt((br['x'] - bl['x'])**2 + (br['y'] - bl['y'])**2)
+
+    # Apply footprint offset: shift foot away from camera by width_m/2
+    # along the camera→foot bearing to approximate object center.
+    cam = camera_origin
+    foot_dx = world['x'] - cam[0]
+    foot_dy = world['y'] - cam[1]
+    bearing_len = math.sqrt(foot_dx**2 + foot_dy**2)
+    if bearing_len > 1e-9:
+      half_size = width_m / 2.0
+      world['x'] += (foot_dx / bearing_len) * half_size
+      world['y'] += (foot_dy / bearing_len) * half_size
+
     test_cases.append({
       'name': bbox['name'],
       'bbox': {'x': bbox['x'], 'y': bbox['y'], 'width': bbox['width'], 'height': bbox['height']},

--- a/tracker/test/unit/coordinate_transformer_test.cpp
+++ b/tracker/test/unit/coordinate_transformer_test.cpp
@@ -111,10 +111,12 @@ const CameraTestConfig kCameraAtaqQcam1 = {
     {1.0, 1.0, 1.0}};
 
 // Bbox foot-to-world reference data for atag-qcam1
+// NOTE: world positions include footprint offset (foot shifted away from camera
+// by width_m/2 along the camera→foot bearing) to approximate object center.
 const std::vector<BboxFootTestCase> kAtaqQcam1BboxTests = {
-    {"center_person", 590.0, 260.0, 100.0, 200.0, 3.6344901016966507, 2.392939581932098},
-    {"top_left_person", 10.0, 10.0, 80.0, 160.0, 1.2282759561369583, 6.183174458656931},
-    {"bottom_right_person", 1190.0, 550.0, 80.0, 160.0, 4.829388967448987, 0.741790968197878},
+    {"center_person", 590.0, 260.0, 100.0, 200.0, 3.6902042231496193, 2.5808369089270590},
+    {"top_left_person", 10.0, 10.0, 80.0, 160.0, 1.1492465718921960, 6.4519638750283645},
+    {"bottom_right_person", 1190.0, 550.0, 80.0, 160.0, 4.9361860976576870, 0.7728640267176475},
 };
 
 // Bbox size-to-world reference data for atag-qcam1


### PR DESCRIPTION
## 📝 Description

Adds footprint offset to the tracker service's camera-to-world projection to match the controller's behavior. Without this offset, large objects observed by multiple cameras are projected to different ground points (each biased toward the observing camera), causing the tracker to create duplicate objects when the gap exceeds the 2.0m matching threshold.

The fix shifts the projected foot point away from the camera along the camera→object bearing by half the object's projected width, matching `moving_object.py::mapObjectDetectionToWorld()`.

See Testing Scenarios for verification steps.

## ✨ Type of Change

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

How to verify the fix:

1. Change the line `categories: [person]` to `categories: [FW190D]` in `tools/tracker/evaluation/pipeline_configs/black_box/black_box_tracker_service.yaml`

2. Run the following commands before and after applying the fix:
```
make build-all
git checkout tdorau/tracker-evaluation-improvements
cd tools/tracker/evaluation
python -m venv .venv
source .venv/bin/activate
pip install -r requirements.txt
python pipeline_engine.py pipeline_configs/black_box/black_box_tracker_service.yaml
```

3. Compare distance error in files `tools/tracker/evaluation/output/black-box-evaluation/{date}_{time}_Tracker-Service/evaluators/DiagnosticEvaluator/DIST_T.png` for both runs. It is above 2 meters before and around 1 meter after the fix.

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

- [x] 🔍 PR title is clear and descriptive
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [x] ✅ I have added tests that prove my fix is effective or my feature works

## Changes

- **`tracker/src/coordinate_transformer.cpp`** — After projecting the bottom-center of the bounding box to the ground plane, shift the point away from the camera by `width_m / 2` along the camera→foot bearing. This aligns projections from different cameras toward the object center, keeping them within the tracking distance threshold.
- **`tracker/test/unit/coordinate_transformer_test.cpp`** — Updated reference world positions to account for the footprint offset.
- **`tracker/test/tools/generate_reference_data.py`** — Updated reference data generator to include footprint offset in bbox foot-to-world computation.
