### PR TITLE
ITEP-92098: Fix API post/put request skips required fields validation

### DIFF
--- a/manager/src/manager/api.py
+++ b/manager/src/manager/api.py
@@ -192,7 +192,7 @@ class ManageThing(APIView):
         thing,
         data=request.data,
         partial=True
-    ) if thing else thing_serializer(data=request.data, partial=True)
+    ) if thing else thing_serializer(data=request.data)
 
     if not serializer.is_valid():
       raise ValidationError(serializer.errors)

--- a/manager/src/manager/serializers.py
+++ b/manager/src/manager/serializers.py
@@ -70,6 +70,12 @@ class PointsSerializerField(serializers.DictField):
     return points
 
   def to_internal_value(self, data):
+    if not isinstance(data, list):
+      raise serializers.ValidationError("Points must be a list.")
+    for i, point in enumerate(data):
+      if not isinstance(point, (list, tuple)) or len(point) != 2:
+        raise serializers.ValidationError(
+          f"Each point must be a list of 2 coordinates, got {point} at index {i}.")
     return data
 
   @staticmethod

--- a/manager/src/manager/serializers.py
+++ b/manager/src/manager/serializers.py
@@ -169,11 +169,11 @@ class SingletonScalarThresholdSerializer(RegionOccupancyThresholdSerializer):
 class SingletonSerializer(NonNullSerializer):
   name = serializers.CharField(max_length=150)
   uid = serializers.CharField(source="sensor_id", read_only=True)
-  scene = serializers.CharField(source='scene.pk', allow_null=True)
-  center = CenterSerializerField(source='*')
-  points = PointsSerializerField()
+  scene = serializers.CharField(source='scene.pk', allow_null=True, required=False)
+  center = CenterSerializerField(source='*', required=False)
+  points = PointsSerializerField(required=False)
   translation = serializers.SerializerMethodField('get_translation')
-  color_ranges = SingletonScalarThresholdSerializer(source='singleton_scalar_threshold')
+  color_ranges = SingletonScalarThresholdSerializer(source='singleton_scalar_threshold', required=False)
 
   def get_translation(self, obj):
     return [obj.map_x, obj.map_y, 0.0]
@@ -263,9 +263,9 @@ class CamSerializer(NonNullSerializer):
   translation = serializers.SerializerMethodField('get_translation')
   rotation = serializers.SerializerMethodField('get_rotation')
   scale = serializers.SerializerMethodField('get_scale')
-  resolution = ResolutionSerializerField(source='cam')
+  resolution = ResolutionSerializerField(source='cam', required=False)
   transforms = serializers.SerializerMethodField('get_transform')
-  scene = serializers.CharField(source="scene.pk", allow_null=True)
+  scene = serializers.CharField(source="scene.pk", allow_null=True, required=False)
   transform_type = serializers.SerializerMethodField('get_transform_type')
 
   def validate_name(self, value):
@@ -485,7 +485,7 @@ class RegionSerializer(NonNullSerializer):
   uid = serializers.SerializerMethodField('get_uuid')
   points = PointsSerializerField()
   scene = serializers.CharField(source='scene.pk')
-  color_ranges = RegionOccupancyThresholdSerializer(source='roi_occupancy_threshold')
+  color_ranges = RegionOccupancyThresholdSerializer(source='roi_occupancy_threshold', required=False)
 
   def create_update(self, validated_data, instance=None):
     is_update = instance is not None


### PR DESCRIPTION
## 📝 Description

DRF now enforces ALL explicitly declared fields as required. Mark scene, center, points, color_ranges - all optional depending on sensor type (circle vs poly vs scene-area). Also fixes validation of points structure.

Now all sensor api test passed. Test Vision_AI/SSCAPE/API/SENSOR/06 is fixed by https://github.com/open-edge-platform/scenescape/pull/1481
<img width="1128" height="67" alt="image" src="https://github.com/user-attachments/assets/3c2a9c3a-a9fc-45a3-9305-eb419b2f1151" />


<!--
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
