### PR TITLE
ITEP-92925: Fix child scene detections dropped by time chunking tracker

### DIFF
--- a/controller/src/controller/time_chunking.py
+++ b/controller/src/controller/time_chunking.py
@@ -158,18 +158,18 @@ class TimeChunkedIntelLabsTracking(IntelLabsTracking):
     # Objects come from either a Camera (cameraID) or a child Scene (uid).
     if len(objects) > 0:
       source = getattr(objects[0], 'camera', None)
-      camera_id = getattr(source, 'cameraID', None) or getattr(source, 'uid', None)
-      if camera_id is None:
-        log.warning("No source ID (cameraID/uid) found in objects, skipping time chunking processing")
+      source_id = getattr(source, 'cameraID', None) or getattr(source, 'uid', None)
+      if source_id is None:
+        log.warning("No source ID found in objects, skipping time chunking processing")
         return
     else:
       # Keep retirement moving when a camera/category has no detections.
-      camera_id = self.EMPTY_FRAME_CAMERA_ID
+      source_id = self.EMPTY_FRAME_CAMERA_ID
 
     for category in categories:
       # Use time chunking
       self.time_chunk_processor.add_message(
-          camera_id, category, objects, when, already_tracked_objects)
+          source_id, category, objects, when, already_tracked_objects)
 
   def _createIlabsTrackers(self, categories, max_unreliable_time, non_measurement_time_dynamic, non_measurement_time_static):
     """Create IntelLabs tracker object for each category"""

--- a/controller/src/controller/time_chunking.py
+++ b/controller/src/controller/time_chunking.py
@@ -159,8 +159,11 @@ class TimeChunkedIntelLabsTracking(IntelLabsTracking):
       try:
         camera_id = objects[0].camera.cameraID
       except (AttributeError, IndexError):
-        log.warning("No camera ID found in objects, skipping time chunking processing")
-        return
+        # Child scene objects have a Scene as camera, use its uid instead
+        camera_id = getattr(objects[0].camera, 'uid', None)
+        if camera_id is None:
+          log.warning("No camera ID found in objects, skipping time chunking processing")
+          return
     else:
       # Keep retirement moving when a camera/category has no detections.
       camera_id = self.EMPTY_FRAME_CAMERA_ID

--- a/controller/src/controller/time_chunking.py
+++ b/controller/src/controller/time_chunking.py
@@ -160,7 +160,7 @@ class TimeChunkedIntelLabsTracking(IntelLabsTracking):
       source = objects[0].camera
       camera_id = getattr(source, 'cameraID', None) or getattr(source, 'uid', None)
       if camera_id is None:
-        log.warning("No camera ID found in objects, skipping time chunking processing")
+        log.warning("No source ID (cameraID/uid) found in objects, skipping time chunking processing")
         return
     else:
       # Keep retirement moving when a camera/category has no detections.

--- a/controller/src/controller/time_chunking.py
+++ b/controller/src/controller/time_chunking.py
@@ -157,7 +157,7 @@ class TimeChunkedIntelLabsTracking(IntelLabsTracking):
     # Extract camera_id from objects - required for time chunking.
     # Objects come from either a Camera (cameraID) or a child Scene (uid).
     if len(objects) > 0:
-      source = objects[0].camera
+      source = getattr(objects[0], 'camera', None)
       camera_id = getattr(source, 'cameraID', None) or getattr(source, 'uid', None)
       if camera_id is None:
         log.warning("No source ID (cameraID/uid) found in objects, skipping time chunking processing")

--- a/controller/src/controller/time_chunking.py
+++ b/controller/src/controller/time_chunking.py
@@ -154,16 +154,14 @@ class TimeChunkedIntelLabsTracking(IntelLabsTracking):
     if not categories:
       categories = self.trackers.keys()
 
-    # Extract camera_id from objects - required for time chunking
+    # Extract camera_id from objects - required for time chunking.
+    # Objects come from either a Camera (cameraID) or a child Scene (uid).
     if len(objects) > 0:
-      try:
-        camera_id = objects[0].camera.cameraID
-      except (AttributeError, IndexError):
-        # Child scene objects have a Scene as camera, use its uid instead
-        camera_id = getattr(objects[0].camera, 'uid', None)
-        if camera_id is None:
-          log.warning("No camera ID found in objects, skipping time chunking processing")
-          return
+      source = objects[0].camera
+      camera_id = getattr(source, 'cameraID', None) or getattr(source, 'uid', None)
+      if camera_id is None:
+        log.warning("No camera ID found in objects, skipping time chunking processing")
+        return
     else:
       # Keep retirement moving when a camera/category has no detections.
       camera_id = self.EMPTY_FRAME_CAMERA_ID

--- a/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
+++ b/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
@@ -5,8 +5,6 @@
 
 from unittest.mock import patch, MagicMock
 
-import pytest
-
 from controller.time_chunking import TimeChunkedIntelLabsTracking
 
 class _ChildSceneSource:

--- a/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
+++ b/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from controller.time_chunking import TimeChunkedIntelLabsTracking
+
+
+class _ChildSceneSource:
+  """Mimics a child Scene object used as 'camera' on MovingObject."""
+
+  def __init__(self, uid):
+    self.uid = uid
+
+
+class _FakeMovingObject:
+  """Minimal MovingObject stand-in with a configurable camera attribute."""
+
+  def __init__(self, camera):
+    self.camera = camera
+    self.category = "person"
+
+
+def test_time_chunking_accepts_child_scene_source():
+  """trackObjects enqueues work when source has uid instead of cameraID."""
+  tracker = TimeChunkedIntelLabsTracking(
+    max_unreliable_time=0.2,
+    non_measurement_time_dynamic=0.2,
+    non_measurement_time_static=0.2,
+    time_chunking_rate_fps=20,
+  )
+
+  child_uid = "child-scene-uid-1234"
+  obj = _FakeMovingObject(_ChildSceneSource(child_uid))
+
+  try:
+    with patch.object(
+      tracker, '_createIlabsTrackers'
+    ):
+      mock_processor = MagicMock()
+      tracker.time_chunk_processor = mock_processor
+
+      tracker.trackObjects(
+        [obj], [], 1.0, ["person"],
+        ref_camera_frame_rate=20,
+        max_unreliable_time=0.2,
+        non_measurement_time_dynamic=0.2,
+        non_measurement_time_static=0.2,
+      )
+
+      mock_processor.add_message.assert_called_once()
+      call_args = mock_processor.add_message.call_args
+      assert call_args[0][0] == child_uid, (
+        f"Expected camera_id={child_uid}, got {call_args[0][0]}"
+      )
+  finally:
+    tracker.join()
+
+
+def test_time_chunking_no_warning_for_child_scene_source():
+  """No warning emitted when source has uid instead of cameraID."""
+  tracker = TimeChunkedIntelLabsTracking(
+    max_unreliable_time=0.2,
+    non_measurement_time_dynamic=0.2,
+    non_measurement_time_static=0.2,
+    time_chunking_rate_fps=20,
+  )
+
+  obj = _FakeMovingObject(_ChildSceneSource("child-uid-5678"))
+
+  try:
+    with patch.object(tracker, '_createIlabsTrackers'), \
+         patch("controller.time_chunking.log") as mock_log:
+      tracker.time_chunk_processor = MagicMock()
+
+      tracker.trackObjects(
+        [obj], [], 1.0, ["person"],
+        ref_camera_frame_rate=20,
+        max_unreliable_time=0.2,
+        non_measurement_time_dynamic=0.2,
+        non_measurement_time_static=0.2,
+      )
+
+      mock_log.warning.assert_not_called()
+  finally:
+    tracker.join()

--- a/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
+++ b/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
@@ -9,13 +9,11 @@ import pytest
 
 from controller.time_chunking import TimeChunkedIntelLabsTracking
 
-
 class _ChildSceneSource:
   """Mimics a child Scene object used as 'camera' on MovingObject."""
 
   def __init__(self, uid):
     self.uid = uid
-
 
 class _FakeMovingObject:
   """Minimal MovingObject stand-in with a configurable camera attribute."""
@@ -23,7 +21,6 @@ class _FakeMovingObject:
   def __init__(self, camera):
     self.camera = camera
     self.category = "person"
-
 
 def test_time_chunking_accepts_child_scene_source():
   """trackObjects enqueues work when source has uid instead of cameraID."""
@@ -59,7 +56,6 @@ def test_time_chunking_accepts_child_scene_source():
       )
   finally:
     tracker.join()
-
 
 def test_time_chunking_no_warning_for_child_scene_source():
   """No warning emitted when source has uid instead of cameraID."""

--- a/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
+++ b/tests/sscape_tests/scene_pytest/test_time_chunking_child_scene.py
@@ -3,7 +3,10 @@
 # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from unittest.mock import patch, MagicMock
+
+pytest.importorskip("robot_vision")
 
 from controller.time_chunking import TimeChunkedIntelLabsTracking
 


### PR DESCRIPTION
## 📝 Description

Fix child scene detections being silently dropped by the tracker when time-chunking is enabled. This issue has been revealed after time-chunking becoming the default mode. Retracking must be enabled in the parent scene to reproduce the issue.

When a local child scene publishes detections to the parent scene, `processSceneData` passes the child `Scene` object as the `camera` parameter to `tracker.createObject()`. With time chunking enabled, `TimeChunkedIntelLabsTracking.trackObjects()` tries to access `objects[0].camera.cameraID`, which fails with `AttributeError` because `Scene` objects have `uid` instead of `cameraID`. This causes all child scene detections to be silently skipped with the warning: `"No camera ID found in objects, skipping time chunking processing"`.

The fix replaces the try-catch with `getattr` lookups that check `cameraID` first (Camera objects) then `uid` (child Scene objects), treating both as valid input rather than handling child scenes in the exception path. The previous try-catch is safely removed because: `objects[0]` is already guarded by a length check, `MovingObject.__init__` always sets `.camera`, and `getattr` on `None` safely returns `None` reaching the same warning+return path as before.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually

Steps to reproduce (with the default tracker configuration with time-chunking enabled):
1. Create two scenes: a child scene with cameras/detections and a parent scene with no cameras
2. Link the child to the parent as a local child scene (Euler Angles, identity transform) with retracking enabled
3. Observe detections on the child scene
4. Verify child detections appear on the `external/<child-id>/person` topic
5. Before fix: parent scene shows no detections; controller logs flood with `"No camera ID found in objects, skipping time chunking processing"`
6. After fix: parent scene correctly receives and tracks child scene detections

- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
