### PR TITLE
Fix build failure due to dependency version

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -31,12 +31,12 @@ RUN : \
     && rm -rf /var/lib/apt/lists/*
 
 # mod_qos library is broken on debian 12, so we build it from source
-RUN wget https://sourceforge.net/projects/mod-qos/files/mod_qos-11.76.tar.gz/download -O /tmp/mod_qos-11.76.tar.gz && \
-    tar -xzf /tmp/mod_qos-11.76.tar.gz -C /tmp && \
-    rm /tmp/mod_qos-11.76.tar.gz && \
-    cd /tmp/mod_qos-11.76/apache2 && \
+RUN wget https://sourceforge.net/projects/mod-qos/files/mod_qos-11.79.tar.gz/download -O /tmp/mod_qos-11.79.tar.gz && \
+    tar -xzf /tmp/mod_qos-11.79.tar.gz -C /tmp && \
+    rm /tmp/mod_qos-11.79.tar.gz && \
+    cd /tmp/mod_qos-11.79/apache2 && \
     apxs2 -i -a -c -lssl -l crypto mod_qos.c && \
-    rm -rf /tmp/mod_qos-11.76
+    rm -rf /tmp/mod_qos-11.79
 
 # ---------- Manager Runtime Stage ------------------
 FROM ${RUNTIME_OS_IMAGE} AS scenescape-manager-runtime

--- a/third-party-programs.txt
+++ b/third-party-programs.txt
@@ -5473,7 +5473,7 @@ Apache License
     meson/1.10.2
     minio==7.2.20
         Copyright (c) MinIO, Inc.
-    mod-qos/11.76
+    mod-qos/11.79
     ninja/1.13.2
     opencv/4.13.0
     openssl/3.6.2


### PR DESCRIPTION
## 📝 Description

11.76 version of the mod-qos package is removed from sourceforge.
Bump up to 11.79 is required for scenescape builds to succeed.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
