### PR TITLE
ITEP-94092 WebUI is out of the Cluster Analytics image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,16 @@ help:
 	@echo "Available targets:"
 	@echo "  build-core        (default) Build secrets, core images (excluding mapping, cluster_analytics, and tracker), and install models"
 	@echo "  build-all                   Build secrets, all images, and install models"
-	@echo "  build-experimental          Build experimental images only (mapping, cluster_analytics, and tracker)"
+	@echo "  build-experimental          Build experimental images only (mapping and tracker)"
 	@echo "  build-core-images           Build core microservice images (excluding mapping, cluster_analytics, and tracker) in parallel"
 	@echo "  build-all-images            Build all microservice images in parallel"
-	@echo "  build-experimental-images   Build experimental microservice images (mapping, cluster_analytics, and tracker) in parallel"
+	@echo "  build-experimental-images   Build experimental microservice images (mapping and tracker) in parallel"
 	@echo "  init-secrets                Generate secrets and certificates"
 	@echo "  <image folder>              Build a specific microservice image (autocalibration, controller, etc.)"
 	@echo ""
 	@echo "  demo                        (default) Start the Scenescape demo with core services using Docker Compose"
 	@echo "  demo-all                    Start the Scenescape demo with all services using Docker Compose"
+	@echo "  demo-cluster-analytics      Start the Scenescape demo with cluster analytics service using Docker Compose"
 	@echo "                              (the demo targets require the SUPASS environment variable to be set"
 	@echo "                              as the super user password for logging into Scenescape)"
 	@echo "  demo-tracker                Start the Scenescape demo with Tracker service + Controller in analytics only mode using Docker Compose"
@@ -198,13 +199,13 @@ build-core-images: $(BUILD_DIR)
 	$(MAKE) -j$(JOBS) $(CORE_IMAGE_FOLDERS)
 	@echo "DONE ==> Parallel builds of core folders: $(CORE_IMAGE_FOLDERS)"
 
-# Parallel wrapper for experimental images (mapping, cluster_analytics, and tracker)
+# Parallel wrapper for experimental images (mapping and tracker)
 .PHONY: build-experimental-images
 build-experimental-images: $(BUILD_DIR)
-	@echo "==> Running parallel builds of experimental folders: mapping cluster_analytics tracker"
+	@echo "==> Running parallel builds of experimental folders: mapping tracker"
 	@set -e; trap 'grep --color=auto -i -r --include="*.log" "^error" $(BUILD_DIR) || true' EXIT; \
-	$(MAKE) -j$(JOBS) mapping cluster_analytics tracker
-	@echo "DONE ==> Parallel builds of experimental folders: mapping cluster_analytics tracker"
+	$(MAKE) -j$(JOBS) mapping tracker
+	@echo "DONE ==> Parallel builds of experimental folders: mapping tracker"
 
 # ===================== Cleaning and Rebuilding =======================
 .PHONY: rebuild-core-images
@@ -686,7 +687,11 @@ demo: build-core init-sample-data
 
 .PHONY: demo-all
 demo-all: build-all init-sample-data
-	$(call start_demo,--profile controller --profile experimental)
+	$(call start_demo,--profile controller --profile cluster-analytics --profile experimental)
+
+.PHONY: demo-cluster-analytics
+demo-cluster-analytics: build-all init-sample-data
+	$(call start_demo,--profile controller --profile cluster-analytics)
 
 .PHONY: demo-tracker
 demo-tracker: build-all init-sample-data

--- a/cluster_analytics/Agents.md
+++ b/cluster_analytics/Agents.md
@@ -11,7 +11,7 @@ The **Cluster Analytics** service provides advanced object clustering, tracking,
 
 **Primary Purpose**: Transform individual object detections into meaningful group behaviors by identifying clusters, tracking their lifecycle, detecting geometric patterns, and analyzing movement dynamics.
 
-**Status**: Experimental—enabled via `make build-experimental` or `make build-all`
+**Status**: Production—build via `make cluster_analytics` or `make build-all`
 
 ## Architecture & Components
 
@@ -149,10 +149,11 @@ The **Cluster Analytics** service provides advanced object clustering, tracking,
 
 ```bash
 # From root directory
-make cluster_analytics                  # Build image
+make cluster_analytics                  # Build production image
 make rebuild-cluster_analytics          # Clean + rebuild
-make build-experimental                 # Build experimental services
-make build-all                          # All services including experimental
+make build-all                          # All services
+# Demo image (WebUI included, for development/demo only)
+make -C cluster_analytics build-demo
 ```
 
 ### Running Locally
@@ -329,6 +330,8 @@ Scene Controller
 - Flask+SocketIO server on HTTPS port 9443 (enabled with `--webui`)
 - Real-time visualization of objects and clusters
 - Per-scene DBSCAN parameter controls backed by `set_user_dbscan_params_for_category()`
+- **Requires the demo image**: the production image does not include WebUI dependencies.
+  Build with `make build-demo` in `cluster_analytics/`, then use `scenescape-cluster-analytics-demo` in docker-compose.
 
 ### Future REST API
 

--- a/cluster_analytics/Dockerfile
+++ b/cluster_analytics/Dockerfile
@@ -76,7 +76,8 @@ FROM scenescape-cluster-analytics-runtime AS scenescape-cluster-analytics-demo
 ARG USER_ID=1001
 ARG GROUP_ID=1001
 
-COPY cluster_analytics/tools/webui/requirements-webui.txt /tmp/
+COPY --chown=$USER_ID:$GROUP_ID cluster_analytics/tools/webui/requirements-webui.txt /tmp/
+
 RUN pip install --no-cache-dir -r /tmp/requirements-webui.txt \
     && rm -rf /tmp/*.txt
 

--- a/cluster_analytics/Dockerfile
+++ b/cluster_analytics/Dockerfile
@@ -42,10 +42,9 @@ RUN : \
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir --upgrade setuptools wheel
 
-COPY cluster_analytics/requirements-runtime.txt cluster_analytics/tools/webui/requirements-webui.txt /tmp/
+COPY cluster_analytics/requirements-runtime.txt /tmp/
 RUN pip install --no-cache-dir \
         -r /tmp/requirements-runtime.txt \
-        -r /tmp/requirements-webui.txt \
     && rm -rf /tmp/*.txt
 
 # Copy compiled packages from builder (use system site-packages directly)
@@ -61,15 +60,27 @@ COPY --chown=$WSUSER:$WSUSER --from=scenescape-cluster-analytics-builder \
 COPY --chown=$USER_ID:$GROUP_ID --from=scenescape-cluster-analytics-builder \
     /tmp/tools/waitforbroker $SCENESCAPE_HOME/tools/waitforbroker
 
-# Copy application code, config, and tools
+# Copy application code and config
 COPY --chown=$USER_ID:$GROUP_ID ./cluster_analytics/src /app
 COPY --chown=$USER_ID:$GROUP_ID ./cluster_analytics/config /app/config
-COPY --chown=$USER_ID:$GROUP_ID ./cluster_analytics/tools /app/tools
 
 USER $USER_ID:$GROUP_ID
 HEALTHCHECK CMD true
 
 ENTRYPOINT ["python3", "/app/cluster_analytics.py"]
+
+# ---------- Cluster Analytics Demo Stage ------------------
+# Extends the runtime image with WebUI for visualization demos
+FROM scenescape-cluster-analytics-runtime AS scenescape-cluster-analytics-demo
+
+ARG USER_ID=1001
+ARG GROUP_ID=1001
+
+COPY cluster_analytics/tools/webui/requirements-webui.txt /tmp/
+RUN pip install --no-cache-dir -r /tmp/requirements-webui.txt \
+    && rm -rf /tmp/*.txt
+
+COPY --chown=$USER_ID:$GROUP_ID ./cluster_analytics/tools /app/tools
 
 # ---------- Cluster Analytics Test Stage ------------------
 FROM scenescape-cluster-analytics-runtime AS scenescape-cluster-analytics-test

--- a/cluster_analytics/Makefile
+++ b/cluster_analytics/Makefile
@@ -7,6 +7,10 @@ USES_SCENE_COMMON := yes
 
 include ../common.mk
 
+.PHONY: build-demo
+build-demo:
+	$(MAKE) IMAGE="scenescape-cluster-analytics-demo" TARGET="scenescape-cluster-analytics-demo"
+
 .PHONY: test-build
 test-build:
 	$(MAKE) IMAGE="scenescape-cluster-analytics-test" TARGET="scenescape-cluster-analytics-test"

--- a/cluster_analytics/tools/webui/README.md
+++ b/cluster_analytics/tools/webui/README.md
@@ -2,6 +2,10 @@
 
 This README explains how to enable the WebUI for Cluster Analytics in the Scenescape demo setup.
 
+> **Note:** The WebUI is not part of the production image. It is shipped in a
+> separate demo image (`scenescape-cluster-analytics-demo`) and is intended for
+> development and demo use only.
+
 ## Cluster Analytics WebUI Features
 
 - Real-time cluster visualization
@@ -10,12 +14,27 @@ This README explains how to enable the WebUI for Cluster Analytics in the Scenes
 
 ## 🚀 Quick Start
 
-The WebUI is **disabled by default**. To enable it, follow the instructions below, then run:
+The WebUI is **disabled by default**. To enable it:
 
-```bash
-cd /path/to/scenescape
-SUPASS=admin123 make demo-all
-```
+1. **Build the demo image** (includes WebUI dependencies):
+
+   ```bash
+   cd /path/to/scenescape
+   make -C cluster_analytics build-demo
+   ```
+
+2. **Update docker-compose** to use the demo image for the `cluster-analytics` service:
+
+   ```yaml
+   cluster-analytics:
+     image: scenescape-cluster-analytics-demo:${VERSION:-latest}
+   ```
+
+3. **Follow the enable steps below**, then run:
+
+   ```bash
+   SUPASS=admin123 make demo-cluster-analytics
+   ```
 
 After enabling, access the WebUI at: **https://localhost:9443**
 

--- a/sample_data/docker-compose-dl-streamer-example.yml
+++ b/sample_data/docker-compose-dl-streamer-example.yml
@@ -90,7 +90,7 @@ x-controller-base: &controller-base
 
 # Profiles:
 # - Default (no profile): Core services including autocalibration
-# - experimental: All services including mapping and cluster-analytics
+# - experimental: All services including mapping
 # - mapping: Core services + mapping only
 # - cluster-analytics: Core services + cluster-analytics only
 # - vdms: Enable the VDMS service
@@ -578,7 +578,6 @@ services:
       OMP_NUM_THREADS: "2"
       MKL_NUM_THREADS: "2"
     profiles:
-      - experimental
       - cluster-analytics
     image: scenescape-cluster-analytics:${VERSION:-latest}
     init: true


### PR DESCRIPTION
## 📝 Description

This pull request updates the build and deployment process for the Cluster Analytics service, separating its production and demo (WebUI-enabled) images, and clarifies its status as a production service. It also updates documentation and Makefile targets to reflect these changes, ensuring that the WebUI is only included in a dedicated demo image and not in the production image.

**Build and Image Changes:**
- The `cluster_analytics` production image no longer includes WebUI dependencies; a new `scenescape-cluster-analytics-demo` image is introduced for demo and development use, containing the WebUI. The Dockerfile and Makefile are updated accordingly. [[1]](diffhunk://#diff-f4b46c3d350f4ef51caddeed3e4e7b5571163767b7c1388bdf986ce367c2199cL45-L48) [[2]](diffhunk://#diff-f4b46c3d350f4ef51caddeed3e4e7b5571163767b7c1388bdf986ce367c2199cL64-R84) [[3]](diffhunk://#diff-3e5756bafaa1908b3b59a2a104b605924e463909cb5b406c066ea5786862f338R10-R13)

**Makefile and Build Process Updates:**
- Makefile targets and help descriptions are updated to reflect that `cluster_analytics` is now a production service, and experimental builds no longer include it. New targets for running the demo with cluster analytics and for building the demo image are added. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L84-R93) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L201-R208) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L689-R694)

**Documentation Updates:**
- The status of Cluster Analytics is changed from experimental to production in `cluster_analytics/Agents.md`, with updated build and run instructions for both production and demo images. [[1]](diffhunk://#diff-bc34af7b3ac1d0172743a12dd2c72bdaaf9419f5479b4fbfb8ebfb0cd55dc5b1L14-R14) [[2]](diffhunk://#diff-bc34af7b3ac1d0172743a12dd2c72bdaaf9419f5479b4fbfb8ebfb0cd55dc5b1L152-R156) [[3]](diffhunk://#diff-bc34af7b3ac1d0172743a12dd2c72bdaaf9419f5479b4fbfb8ebfb0cd55dc5b1R333-R334)
- The WebUI documentation is revised to clarify that the WebUI is only available in the demo image, with step-by-step instructions for building and running it. [[1]](diffhunk://#diff-81e5c7649e62ba75982519bc3c2b276d4a3868e13f0d1999e2c44a98c01a87b6R5-R8) [[2]](diffhunk://#diff-81e5c7649e62ba75982519bc3c2b276d4a3868e13f0d1999e2c44a98c01a87b6L13-R36)

**Docker Compose and Profile Clarifications:**
- Docker Compose example and profile comments are updated to reflect that the experimental profile no longer includes cluster analytics, and the cluster analytics service is now deployed with its own profile. [[1]](diffhunk://#diff-220a12094fbc395bd75f1d847eafc93a5621aadeff24111365a67b3fc2f73e90L93-R93) [[2]](diffhunk://#diff-220a12094fbc395bd75f1d847eafc93a5621aadeff24111365a67b3fc2f73e90L581)

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [x] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [x] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
