### PR TITLE
ITEP-93342 Changed Mapping Service image naming and tagging convention

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SHELL := /bin/bash
-VERSION := $(shell cat ../version.txt)
+VERSION ?= $(shell cat ../version.txt)
 BUILD_DIR ?= $(PWD)/build
 ROOT_DIR := $(PWD)
 LOG_FILE := $(BUILD_DIR)/$(IMAGE).log

--- a/mapping/Makefile
+++ b/mapping/Makefile
@@ -9,6 +9,7 @@ TEST_IMAGE := intel/scenescape-mapping-$(MODEL_TYPE)-test
 TARGET = mapping-runtime
 TEST_TARGET = mapping-test
 USES_SCENE_COMMON := yes
+VERSION := $(shell cat ../version.txt)
 
 include ../common.mk
 
@@ -21,14 +22,16 @@ test-build:
 
 .PHONY: build-vggt
 build-vggt:
-	$(MAKE) MODEL_TYPE=vggt IMAGE="intel/scenescape-mapping-vggt"
+	$(MAKE) MODEL_TYPE=vggt IMAGE="intel/scenescape-mapping" VERSION=$(VERSION)-vggt
 
 .PHONY: build-mapanything
 build-mapanything:
-	$(MAKE) MODEL_TYPE=mapanything IMAGE="intel/scenescape-mapping-mapanything"
+	$(MAKE) MODEL_TYPE=mapanything IMAGE="intel/scenescape-mapping" VERSION=$(VERSION)-mapanything
 
 .PHONY: build-all
 build-all: build-vggt build-mapanything
+	docker tag intel/scenescape-mapping:$(VERSION)-mapanything intel/scenescape-mapping:latest
+	docker tag intel/scenescape-mapping:$(VERSION)-mapanything intel/scenescape-mapping:$(VERSION)
 
 # Convenience targets
 .PHONY: vggt mapanything


### PR DESCRIPTION
## 📝 Description

Changed Mapping naming and tagging convention. Models are now part of tag instead of image name to follow good practices of creating image variants.

Before:
```
intel/scenescape-mapping:2026.2.0 # default using mapanything
intel/scenescape-mapping-mapanything:2026.2.0
intel/scenescape-mapping-vggt:2026.2.0
```

Now
```
intel/scenescape-mapping:2026.2.0 # default using mapanything
intel/scenescape-mapping:2026.2.0-mapanything
intel/scenescape-mapping:2026.2.0-vggt
```

This approach makes it possible to store all images under a single container repo.


## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
