### PR TITLE
Potential fix for code scanning alert no. 964: Uncontrolled data used in path expression

### DIFF
--- a/manager/src/manager/views.py
+++ b/manager/src/manager/views.py
@@ -119,7 +119,13 @@ def protected_media(request, path, media_root):
 
 def list_resources(request, folder_name):
   """! List files in folder_name inside MEDIA_ROOT and return them as JSON."""
-  base_path = os.path.join(settings.MEDIA_ROOT, folder_name)
+  media_root = os.path.realpath(settings.MEDIA_ROOT)
+  base_path = os.path.realpath(os.path.join(media_root, folder_name))
+
+  # Ensure the resolved path stays within MEDIA_ROOT.
+  if os.path.commonpath([media_root, base_path]) != media_root:
+    return JsonResponse({"error": "Invalid folder"}, status=400)
+
   if not os.path.exists(base_path) or not os.path.isdir(base_path):
     return JsonResponse({"error": "Invalid folder"}, status=400)
   files = [f for f in os.listdir(base_path) if os.path.isfile(os.path.join(base_path, f))]


### PR DESCRIPTION
Potential fix for [https://github.com/open-edge-platform/scenescape/security/code-scanning/964](https://github.com/open-edge-platform/scenescape/security/code-scanning/964)

General fix: canonicalize the constructed path and enforce that it remains inside a trusted root directory before any filesystem access.

Best fix here (without changing intended functionality): in `manager/src/manager/views.py`, update `list_resources` to:
1. Resolve `MEDIA_ROOT` to an absolute real path.
2. Resolve the user-requested subpath against it.
3. Reject the request unless the resolved target is within the resolved root (use `os.path.commonpath`).
4. Keep existing behavior for invalid/missing folders and file listing.

No new dependency is needed; `os.path.realpath`/`os.path.commonpath` are already available via existing `os` import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
