### PR TITLE
ITEP 81442: registration error status is not properly handled

### DIFF
--- a/manager/src/manager/static/js/calibration.js
+++ b/manager/src/manager/static/js/calibration.js
@@ -120,7 +120,21 @@ async function registerAutoCameraCalibration(scene_id, socket) {
   socket.on("register_result", async (notification) => {
     manageCalibrationState(notification.data, scene_id);
   });
-  const response = await registerScene(scene_id);
+
+  // The registration POST resolves synchronously with an error when the scene
+  // map wasn't just updated, in which case no "register_result" socket event
+  // is ever emitted, so the response must be handled here too.
+  try {
+    const response = await registerScene(scene_id);
+    if (response) {
+      await manageCalibrationState(response, scene_id);
+    }
+  } catch (error) {
+    await manageCalibrationState(
+      { status: "error", message: error.message },
+      scene_id,
+    );
+  }
 }
 
 async function manageCalibrationState(msg, scene_id) {
@@ -149,6 +163,11 @@ async function manageCalibrationState(msg, scene_id) {
       }
     } else if (msg.status == "re-register") {
       const response = await registerScene(scene_id);
+    } else if (msg.status == "error") {
+      document.getElementById("calib-spinner").classList.add("hide-spinner");
+      document.getElementById("auto-autocalibration").disabled = true;
+      document.getElementById("auto-autocalibration").title =
+        msg.message || "Auto camera calibration failed";
     } else {
       document.getElementById("calib-spinner").classList.add("hide-spinner");
       document.getElementById("auto-autocalibration").title = msg.status;

--- a/manager/src/manager/static/js/calibration.js
+++ b/manager/src/manager/static/js/calibration.js
@@ -118,7 +118,7 @@ async function registerAutoCameraCalibration(scene_id, socket) {
   }
 
   socket.on("register_result", async (notification) => {
-    manageCalibrationState(notification.data, scene_id);
+    await manageCalibrationState(notification.data, scene_id);
   });
 
   // The registration POST resolves synchronously with an error when the scene
@@ -162,7 +162,17 @@ async function manageCalibrationState(msg, scene_id) {
           "Click to calibrate the camera automatically";
       }
     } else if (msg.status == "re-register") {
-      const response = await registerScene(scene_id);
+      try {
+        const response = await registerScene(scene_id);
+        if (response) {
+          await manageCalibrationState(response, scene_id);
+        }
+      } catch (error) {
+        await manageCalibrationState(
+          { status: "error", message: error.message },
+          scene_id,
+        );
+      }
     } else if (msg.status == "error") {
       document.getElementById("calib-spinner").classList.add("hide-spinner");
       document.getElementById("auto-autocalibration").disabled = true;

--- a/tests/ui/test_auto_calibration_registration_error_ui.py
+++ b/tests/ui/test_auto_calibration_registration_error_ui.py
@@ -88,7 +88,7 @@ def test_registration_error_status_handled(request, record_xml_attribute, scenes
   @param    record_xml_attribute    Pytest fixture recording the test name.
   @return   exit_code               Indicates test success or failure.
   """
-  TEST_NAME = "NEX-T#####"
+  TEST_NAME = "NEX-T27164"
   record_xml_attribute("name", TEST_NAME)
 
   test = RegistrationErrorHandlingTest(TEST_NAME, request, record_xml_attribute)

--- a/tests/ui/test_auto_calibration_registration_error_ui.py
+++ b/tests/ui/test_auto_calibration_registration_error_ui.py
@@ -45,6 +45,11 @@ class RegistrationErrorHandlingTest(UserInterfaceTest):
       lambda d: self.wait_for_button_label(d, expected_label, actual_label, button_id)
     )
 
+    button_element = self.browser.find_element(By.ID, button_id)
+    if button_element.is_enabled():
+      print("Auto calibration button should be disabled after the async registration error path.")
+      return
+
     # Reloading now hits the synchronous registration-error path, which never emits
     # a "register_result" socket event, previously leaving the button stuck on
     # "Initializing auto camera calibration".

--- a/tests/ui/test_auto_calibration_registration_error_ui.py
+++ b/tests/ui/test_auto_calibration_registration_error_ui.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from tests.ui import UserInterfaceTest
+from tests.ui import common
+from tests.utils.spec import FuncTestSpec
+from tests.utils.profiles import FULL_STACK_AUTOCALIBRATION_NO_APRILTAGS
+
+SCENESCAPE_SPEC = FuncTestSpec(
+  profile=FULL_STACK_AUTOCALIBRATION_NO_APRILTAGS,
+  require_password=True, auth="",
+)
+
+class RegistrationErrorHandlingTest(UserInterfaceTest):
+  def __init__(self, testName, request, recordXMLAttribute):
+    super().__init__(testName, request, recordXMLAttribute)
+    self.sceneName = self.params['scene']
+    self.exitCode = 1
+    return
+
+  def wait_for_button_label(self, driver, expected_label, actual_label, button_id):
+    value = driver.find_element(By.ID, button_id).get_attribute("title")
+    actual_label['value'] = value
+    return value == expected_label
+
+  def execute_test(self):
+    """! Executes test case """
+    expected_label = "Cannot auto calibrate. Check scene to ensure there are at least 4 april tags"
+    actual_label = {"value": None}
+    cam_url = "/cam/calibrate/1"
+    button_id = "auto-autocalibration"
+    timeout = 120
+
+    assert self.login()
+
+    # First visit takes the async registration path (map not yet processed) and
+    # leaves the scene's map marked as processed once it settles.
+    print("Navigating to camera1 page to let the first registration settle.")
+    self.navigateDirectlyToPage(cam_url)
+    WebDriverWait(self.browser, timeout).until(
+      lambda d: self.wait_for_button_label(d, expected_label, actual_label, button_id)
+    )
+
+    # Reloading now hits the synchronous registration-error path, which never emits
+    # a "register_result" socket event, previously leaving the button stuck on
+    # "Initializing auto camera calibration".
+    print("Reloading the page to force a synchronous registration error response.")
+    actual_label['value'] = None
+    self.browser.refresh()
+
+    print(f"Checking auto calibration button label after reload. Timeout: {timeout}")
+    try:
+      WebDriverWait(self.browser, timeout).until(
+        lambda d: self.wait_for_button_label(d, expected_label, actual_label, button_id)
+      )
+      print("Autocalibration label displays correct message after reload.")
+    except TimeoutException:
+      print(
+        f"Autocalibration label did not display expected message within {timeout} seconds. "
+        f"Last observed label: {actual_label['value']!r}, expected: {expected_label!r}."
+      )
+
+    print("Checking button state is disabled.")
+    button_element = self.browser.find_element(By.ID, button_id)
+    button_is_disabled = not button_element.is_enabled()
+
+    if actual_label['value'] == expected_label and button_is_disabled:
+      self.exitCode = 0
+      print("Button state is correct and label displays correct message after a synchronous registration error.")
+    else:
+      print("Autocalibration label or button state is incorrect after a synchronous registration error.")
+
+@common.mock_display
+def test_registration_error_status_handled(request, record_xml_attribute, scenescape_env):
+  """! Checks that a synchronous registration-error response (no register_result socket
+  event) still updates the Auto Calibrate button/tooltip instead of leaving it stuck on
+  "Initializing auto camera calibration".
+  @param    request                  Dict of test parameters.
+  @param    record_xml_attribute    Pytest fixture recording the test name.
+  @return   exit_code               Indicates test success or failure.
+  """
+  TEST_NAME = "NEX-T#####"
+  record_xml_attribute("name", TEST_NAME)
+
+  test = RegistrationErrorHandlingTest(TEST_NAME, request, record_xml_attribute)
+  test.execute_test()
+
+  common.record_test_result(TEST_NAME, test.exitCode)
+
+  assert test.exitCode == 0
+  return test.exitCode
+
+def main():
+  return test_registration_error_status_handled(None, None)
+
+if __name__ == '__main__':
+  os._exit(main() or 0)


### PR DESCRIPTION
## 📝 Description

ITEP 81442

- Added a try/catch around the registerScene() call in registerAutoCameraCalibration() (calibration.js), so a synchronous error response from the POST .../scenes/<id>/registration endpoint is now forwarded to manageCalibrationState() instead of being silently discarded - previously the button state relied solely on the register_result WebSocket event, which is never emitted when the backend resolves the error synchronously
- Added a new "error" branch to manageCalibrationState() (calibration.js) that hides the spinner, disables the "Auto Calibrate" button, and sets its tooltip to the backend-provided message.
- Added test_auto_calibration_registration_error_ui.py, a regression test that first exercises the pre-existing asynchronous no-apriltags path, then reloads the page to force the same registration call down the synchronous error path, asserting the button reaches the disabled state with the correct tooltip in both cases.

Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

<!--
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [x] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
