### PR TITLE
ITEP 81227: polycam data cannot be overwritten by upload

### DIFF
--- a/manager/src/manager/forms.py
+++ b/manager/src/manager/forms.py
@@ -107,12 +107,11 @@ class SceneUpdateForm(ModelForm):
     model = Scene
     fields = ('__all__')
 
-  def checkDuplicatePolycamData(self, zip_file, field_name):
+  def updatePolycamHash(self, zip_file):
+    # Re-uploading a zip (even one identical to the current data) must always be allowed to save.
     file_hash = hashlib.sha256(zip_file.read()).hexdigest()
-    if self.instance.polycam_hash == file_hash:
-      self.add_error(field_name, "Uploading a duplicate zip file is not allowed. Please clear the field and upload again.")
-    else:
-      self.instance.polycam_hash = file_hash
+    zip_file.seek(0)
+    self.instance.polycam_hash = file_hash
     return
 
   def clean(self):
@@ -124,10 +123,10 @@ class SceneUpdateForm(ModelForm):
     if new_map_file:
       map_file_ext = os.path.splitext(new_map_file.name)[1].lower()
       if map_file_ext == ".zip":
-        self.checkDuplicatePolycamData(new_map_file, 'map')
+        self.updatePolycamHash(new_map_file)
         validate_zip_file(new_map_file)
     if new_polycam_file:
-      self.checkDuplicatePolycamData(new_polycam_file, 'polycam_data')
+      self.updatePolycamHash(new_polycam_file)
       validate_zip_file(new_polycam_file, map_file_ext == ".glb")
     else:
       self.instance.polycam_hash = ""

--- a/tests/sscape_tests/scene/test_scene_polycam_reupload.py
+++ b/tests/sscape_tests/scene/test_scene_polycam_reupload.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import io
+import zipfile
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from manager.forms import SceneUpdateForm
+from manager.models import Scene
+
+
+def buildPolycamZipBytes(image_content=b"jpg-bytes"):
+  buffer = io.BytesIO()
+  with zipfile.ZipFile(buffer, "w") as zf:
+    zf.writestr("dataset/mesh_info.json", "{}")
+    zf.writestr("dataset/raw.glb", b"glb-bytes")
+    zf.writestr("dataset/keyframes/images/frame0.jpg", image_content)
+    zf.writestr("dataset/keyframes/depth/frame0.png", b"png-bytes")
+    zf.writestr("dataset/keyframes/cameras/frame0.json", "{}")
+  return buffer.getvalue()
+
+
+class ScenePolycamReuploadTestCase(TestCase):
+  def setUp(self):
+    self.zip_bytes = buildPolycamZipBytes()
+    self.scene = Scene.objects.create(name="test_polycam_scene")
+    self.scene.polycam_hash = hashlib.sha256(self.zip_bytes).hexdigest()
+    self.scene.save()
+
+  def _requiredFormData(self):
+    # Minimal set of fields the model requires (blank=False) for the form to reach clean().
+    return {
+      "name": self.scene.name,
+      "map_type": "map_upload",
+      "rotation_x": "0", "rotation_y": "0", "rotation_z": "0",
+      "translation_x": "0", "translation_y": "0", "translation_z": "0",
+      "scale_x": "1", "scale_y": "1", "scale_z": "1",
+      "output_lla": "False",
+      "camera_calibration": "Markerless",
+    }
+
+  def test_reupload_identical_polycam_data_is_allowed(self):
+    upload = SimpleUploadedFile("dataset.zip", self.zip_bytes, content_type="application/zip")
+    form = SceneUpdateForm(data=self._requiredFormData(), files={"polycam_data": upload}, instance=self.scene)
+    self.assertTrue(form.is_valid(), form.errors)
+    self.assertNotIn("polycam_data", form.errors)
+
+  def test_reupload_new_polycam_data_is_allowed(self):
+    new_zip_bytes = buildPolycamZipBytes(image_content=b"different-jpg-bytes")
+    self.assertNotEqual(hashlib.sha256(new_zip_bytes).hexdigest(), self.scene.polycam_hash)
+    upload = SimpleUploadedFile("dataset.zip", new_zip_bytes, content_type="application/zip")
+    form = SceneUpdateForm(data=self._requiredFormData(), files={"polycam_data": upload}, instance=self.scene)
+    self.assertTrue(form.is_valid(), form.errors)
+    self.assertNotIn("polycam_data", form.errors)
+
+  def test_invalid_polycam_zip_is_still_rejected(self):
+    invalid_zip_bytes = io.BytesIO()
+    with zipfile.ZipFile(invalid_zip_bytes, "w") as zf:
+      zf.writestr("dataset/not_a_dataset.txt", "no polycam data here")
+    upload = SimpleUploadedFile("dataset.zip", invalid_zip_bytes.getvalue(), content_type="application/zip")
+    form = SceneUpdateForm(data=self._requiredFormData(), files={"polycam_data": upload}, instance=self.scene)
+    self.assertFalse(form.is_valid())
+    self.assertIn("mesh_info.json", str(form.errors))


### PR DESCRIPTION
## 📝 Description

ITEP 81227

- Renamed checkDuplicatePolycamData() to updatePolycamHash() in SceneUpdateForm (forms.py) and removed its add_error() call - re-uploading a zip whose hash matched the existing polycam_hash previously blocked the save with a dead-end "clear and re-upload" error; it now just records the new hash and lets the save proceed.
- Added zip_file.seek(0) after the hash read (forms.py), since validate_zip_file() now always runs afterward on the same file object and would otherwise read from EOF.
- Added test_scene_polycam_reupload.py, covering: re-uploading identical Polycam zip content (previously blocked, now allowed), re-uploading different content (already worked, regression guard), and re-uploading a structurally invalid zip still being rejected.

Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [x] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
