### PR TITLE
ITEP-95153 Added version normalization in SceneScape Manager app

### DIFF
--- a/manager/src/manager/setup.py
+++ b/manager/src/manager/setup.py
@@ -7,6 +7,19 @@ from setuptools import setup, find_packages
 
 import os
 
+
+def normalize_to_pep440(version):
+  """Convert Scenescape tag-style versions to a setuptools-compatible version."""
+  # Keep existing rc normalization behavior.
+  normalized = re.sub(r'(rc\d+)([\d.]+)', lambda m: m.group(1) + m.group(2).replace('.', '-'), version)
+
+  # Convert Docker-style suffixes (e.g. -20260804-weekly) to local version metadata.
+  if '-' in normalized:
+    base, suffix = normalized.split('-', 1)
+    normalized = f"{base}+{suffix.replace('-', '.')}"
+
+  return normalized
+
 # Application Naming
 APP_NAME = 'manager'
 APP_PROPER_NAME = 'Scenescape'
@@ -17,8 +30,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 try:
   with open(os.path.join(BASE_DIR, 'version.txt')) as f:
-    APP_VERSION_NUMBER = f.readline().rstrip()
-    APP_VERSION_NUMBER = re.sub(r'(rc\d+)([\d.]+)', lambda m: m.group(1) + m.group(2).replace('.', '-'), APP_VERSION_NUMBER)
+    APP_VERSION_NUMBER = normalize_to_pep440(f.readline().rstrip())
     print(APP_PROPER_NAME + " version " + APP_VERSION_NUMBER)
 except IOError:
   print(f"{APP_PROPER_NAME} version.txt file not found in {BASE_DIR}")


### PR DESCRIPTION
## 📝 Description

Because Django app needs PEP-404 compliant version, builds were failing for tags like 2026.2.0-20260804-weekly. 
This PR adds version normalization so that app can be built with such version

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
