### PR TITLE
hloc library change to work with pycolmap 4.0.4

### DIFF
--- a/autocalibration/src/reloc/patches/02-extractors-modifications.patch
+++ b/autocalibration/src/reloc/patches/02-extractors-modifications.patch
@@ -207,10 +207,9 @@ diff -Naur '--exclude=__pycache__' '--exclude=*.pyc' /tmp/hloc-latest/hloc/extra
 -            "keypoint_scores": [f.detection_scores for f in features],
 -            "descriptors": [f.descriptors.t() for f in features],
 -        }
-diff -Naur '--exclude=__pycache__' '--exclude=*.pyc' /tmp/hloc-latest/hloc/extractors/dog.py hloc/extractors/dog.py
---- /tmp/hloc-latest/hloc/extractors/dog.py	2026-01-16 16:13:56.813844948 -0700
-+++ hloc/extractors/dog.py	2026-01-16 16:16:08.549199485 -0700
-@@ -1,119 +1,114 @@
+--- /tmp/hloc-latest/hloc/extractors/dog.py
++++ hloc/extractors/dog.py
+@@ -1,119 +1,116 @@
 +# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
 +# SPDX-License-Identifier: Apache-2.0
 +
@@ -222,13 +221,13 @@ diff -Naur '--exclude=__pycache__' '--exclude=*.pyc' /tmp/hloc-latest/hloc/extra
  import torch
 -from kornia.feature.laf import extract_patches_from_pyramid, laf_from_center_scale_ori
 +import pycolmap
- 
+
  from ..utils.base_model import BaseModel
- 
+
 +
  EPS = 1e-6
- 
- 
+
+
  def sift_to_rootsift(x):
 -    x = x / (np.linalg.norm(x, ord=1, axis=-1, keepdims=True) + EPS)
 -    x = np.sqrt(x.clip(min=EPS))
@@ -238,8 +237,8 @@ diff -Naur '--exclude=__pycache__' '--exclude=*.pyc' /tmp/hloc-latest/hloc/extra
 +  x = np.sqrt(x.clip(min=EPS))
 +  x = x / (np.linalg.norm(x, axis=-1, keepdims=True) + EPS)
 +  return x
- 
- 
+
+
  class DoG(BaseModel):
 -    default_conf = {
 -        "options": {
@@ -295,9 +294,11 @@ diff -Naur '--exclude=__pycache__' '--exclude=*.pyc' /tmp/hloc-latest/hloc/extra
 +        options['normalization'] = pycolmap.Normalization.L1_ROOT
 +      else:
 +        options['normalization'] = pycolmap.Normalization.L2
-+      self.sift = pycolmap.Sift(
-+          options=pycolmap.SiftExtractionOptions(options),
-+          device=getattr(pycolmap.Device, 'cuda' if use_gpu else 'cpu'))
++
++      sift_options = pycolmap.SiftExtractionOptions(options)
++      sift_device = getattr(pycolmap.Device, 'cuda' if use_gpu else 'cpu')
++      feature_options = pycolmap.FeatureExtractionOptions(sift=sift_options)
++      self.sift = pycolmap.Sift(options=feature_options, device=sift_device)
 +
 +    keypoints, scores, descriptors = self.sift.extract(image_np)
 +


### PR DESCRIPTION
## 📝 Description

Recently, the pycolmap library has been updated from 0.6.0 to 4.0.4. The latter version is not compatible with hloc library used by the scenescape - which leads to a crash of the autocalibration service during markerless camera calibration. Error appears after configuring scene to use markerless calibration - when a user enters the 3D scene UI - the autocalibration service crashes - in logs there is an exception about incompatible parameters of a call to a pycolmap library.


## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
