### PR TITLE
Creating camera without scene and with name in integer format

### DIFF
--- a/manager/src/manager/serializers.py
+++ b/manager/src/manager/serializers.py
@@ -313,7 +313,7 @@ class CamSerializer(NonNullSerializer):
     if not is_update:
       sensor_id = validated_data.get('sensor_id', None)
       if sensor_id is None:
-        sensor_id = self.initial_data.get('name')
+        sensor_id = validated_data.get('name')
         if sensor_id is not None:
           sensor_id = sensor_id.replace(" ", "_")
         validated_data['sensor_id'] = sensor_id
@@ -404,6 +404,9 @@ class CamSerializer(NonNullSerializer):
     return
 
   def create_camera_instance(self, instance):
+    if instance.scene is None:
+      return
+
     if instance.cam.transforms is None:
       return
 


### PR DESCRIPTION
## 📝 Description

Currently, the POST `/api/v1/camera` endpoint fails in two cases:
- if name in a request body is an integer
- when creating a new camera - a scene id is required whereas according to api specification (https://docs.openedgeplatform.intel.com/dev/scenescape/api-reference.html) it should be optional.

In this PR both issues have been resolved - camera can be created without passing a scene id and integer names are accepted.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

Tests should contain:
- creating a new camera with a name only
- creating/updating a new camera with a name given as an integer

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
