### PR TITLE
fix: calibration raycaster works with arbitrary GLB mesh names

### DIFF
--- a/manager/src/manager/static/js/interactions.js
+++ b/manager/src/manager/static/js/interactions.js
@@ -12,9 +12,17 @@ import {
 import SceneCamera from "/static/js/thing/scenecamera.js";
 
 function isMeshToProjectOn(intersect) {
-  return SCENE_MESH_NAMES.some((name) =>
+  if (SCENE_MESH_NAMES.some((name) =>
     intersect.object.name.toLowerCase().includes(name),
-  );
+  )) return true;
+  // Accept any mesh that is a descendant of the "3d_scene" container,
+  // so GLBs with arbitrary internal mesh names still work.
+  let obj = intersect.object.parent;
+  while (obj) {
+    if (obj.name === "3d_scene") return true;
+    obj = obj.parent;
+  }
+  return false;
 }
 
 function SetupMarkHover(scene, domElement, marks, getCamera) {


### PR DESCRIPTION
isMeshToProjectOn() only matched meshes whose names appeared in the hardcoded SCENE_MESH_NAMES list. GLB files whose internal mesh nodes carry names outside that list (e.g. from a newly uploaded map) caused every ray cast on the scene view to miss, so double-clicking never created a calibration point.

Now, after the name check, the function also walks up the parent chain and accepts any mesh that is a descendant of the '3d_scene' container (the root set on GLTF load), making the check name-agnostic for 3D maps.

## 📝 Description

Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

<!--
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
