### PR TITLE
Passing messages with empty objects list from child to parent scene

### DIFF
--- a/controller/src/controller/scene_controller.py
+++ b/controller/src/controller/scene_controller.py
@@ -275,8 +275,8 @@ class SceneController:
       new_topic = PubSub.formatTopic(PubSub.DATA_SCENE, scene_id=scene.uid,
                                      thing_type=otype)
       self.pubsub.publish(new_topic, jstr)
-      self.publishExternalDetections(scene, otype, objects, jdata)
       scene.lastPubCount[cid] = olen
+    self.publishExternalDetections(scene, otype, objects, jdata)
     return
 
   def publishExternalDetections(self, scene, otype, objects, jdata_base):


### PR DESCRIPTION
## 📝 Description

Currently empty (with an empty objects list) mqtt messages from child scene - were not propagated to the parent scene. It leads to a situation when a parent scene displays findings from a child scene which are no longer valid - as a child scene is empty.

After correction - such messages are propagated properly - so parent scene collects all kind of messages - including empty ones.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

To test it create a parent and a child scene. Child scene should be connected to a camera (movie) - which for some time doesn't detect any objects. Observe mqtt messages - those from the child scene (in "scenescape/regulated/scene" topic) should be propagated to the parent scene - even empty ones.

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
