### PR TITLE
ITEP-95979 trimming username when logging in

### DIFF
--- a/manager/src/manager/views.py
+++ b/manager/src/manager/views.py
@@ -583,7 +583,7 @@ def sign_in(request):
       form.add_error(None, 'Username should not be more than {} characters'.format(maxLength))
 
     if form.is_valid():
-      user = authenticate(username=request.POST['username'], password=request.POST['password'], request=request)
+      user = form.get_user() 
       if user is not None:
         Token.objects.get_or_create(user=user)
         login(request, user)


### PR DESCRIPTION
## 📝 Description

Currently - username is validated twice - first trimmed and then again - raw - with all trailing whitespaces. It leads to a behavior when a user cannot login passing a username with trailing spaces but the application doesn't display any message about it - just clears both fields - username and password - and stays on a login screen.
In this PR this behavior has been aligned - now a user can pass a username with trailing spaces and the system accepts it.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Check if a username with trailing spaces is accepted when logging into the application.

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
