### PR TITLE
ITEP-95979 trimming username when logging in

### DIFF
--- a/manager/src/manager/views.py
+++ b/manager/src/manager/views.py
@@ -583,7 +583,7 @@ def sign_in(request):
       form.add_error(None, 'Username should not be more than {} characters'.format(maxLength))
 
     if form.is_valid():
-      user = authenticate(username=request.POST['username'], password=request.POST['password'], request=request)
+      user = form.get_user()
       if user is not None:
         Token.objects.get_or_create(user=user)
         login(request, user)

--- a/tests/sscape_tests/views/test_views.py
+++ b/tests/sscape_tests/views/test_views.py
@@ -120,6 +120,22 @@ class TestSignInViews(TestCase):
     self.assertTemplateUsed(response, 'sscape/sign_in.html')
     return
 
+  def test_sign_in_post_success(self):
+    response = self.client.post(reverse('sign_in'), data = {'username': ' test_user ', 'password': 'testpassword', 'request': self.request})
+    self.assertEqual(response.status_code, 302)
+    return
+
+  def test_sign_in_post_trims_whitespace(self):
+    response = self.client.post(reverse('sign_in'), data = {'username': ' test_user ', 'password': 'testpassword', 'request': self.request})
+    self.assertEqual(response.status_code, 302)
+    return
+
+  def test_sign_in_post_wrong_username(self):
+    response = self.client.post(reverse('sign_in'), data = {'username': 'wrong_user', 'password': 'testpassword', 'request': self.request})
+    self.assertEqual(response.status_code, 200)
+    self.assertTemplateUsed(response, 'sscape/sign_in.html')
+    return
+
 class TestSignOutViews(SetUpTestCases):
   def test_sign_out(self):
     response = self.client.post(reverse('sign_out'))


### PR DESCRIPTION
## 📝 Description

Currently - username is validated twice - first trimmed and then again - raw - with all trailing whitespaces. It leads to a behavior when a user cannot login passing a username with trailing spaces but the application doesn't display any message about it - just clears both fields - username and password - and stays on a login screen.
In this PR this behavior has been aligned - now a user can pass a username with trailing spaces and the system accepts it.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Check if a username with trailing spaces is accepted when logging into the application.

- [x] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
