### PR TITLE
ITEP-96143 Fix image build for main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ test_reports/
 !tests/interface/firefox-profile.tar
 manager/test/geckodriver.tar.gz
 tests/perf_tests/input/*.json
+
+# Host-side vendored third-party sources for Docker builds (see autocalibration/Makefile,
+# mapping/Makefile vendor-deps targets)
+autocalibration/.vendor/
+mapping/.vendor/
+
 model_installer/models
 package.json
 package-lock.json

--- a/autocalibration/Dockerfile
+++ b/autocalibration/Dockerfile
@@ -32,10 +32,10 @@ COPY autocalibration/src/reloc/patches /tmp/reloc-patches
 COPY autocalibration/src/reloc/new-files /tmp/reloc-new-files
 COPY autocalibration/src/reloc/tests /tmp/reloc-tests
 
-# Clone and patch hloc from latest main
-RUN git clone https://github.com/cvg/Hierarchical-Localization.git /tmp/reloc && \
-    cd /tmp/reloc && \
-    git checkout c13273b && \
+# hloc source is fetched on the host by `make vendor-deps` (see autocalibration/Makefile)
+# to avoid GitHub's unauthenticated-download rate limiting inside the container build.
+COPY autocalibration/.vendor/reloc /tmp/reloc
+RUN cd /tmp/reloc && \
     # Apply patches in order (using -p0 as paths are relative to repo root)
     patch -p0 < /tmp/reloc-patches/00-top-level-files.patch && \
     patch -p0 < /tmp/reloc-patches/01-core-modifications.patch && \
@@ -54,13 +54,13 @@ RUN git clone https://github.com/cvg/Hierarchical-Localization.git /tmp/reloc &&
     rm -rf /tmp/reloc/.git
 
 # Build wheels in parallel (this changes when source or dependencies change)
-# Clone AprilTag
-RUN git clone --depth=1 https://github.com/duckietown/lib-dt-apriltags.git /tmp/apriltag/apriltag-dev
+# AprilTag source (including its 'apriltags' submodule) is fetched on the host by
+# `make vendor-deps` to avoid GitHub's unauthenticated-download rate limiting.
+COPY autocalibration/.vendor/apriltag-dev /tmp/apriltag/apriltag-dev
 
 # Build AprilTag
 WORKDIR /tmp/apriltag/apriltag-dev
-RUN git submodule update --init && \
-    mkdir build
+RUN mkdir build
 
 WORKDIR /tmp/apriltag/apriltag-dev/build
 RUN cmake ../apriltags/ && make -j$(nproc)

--- a/autocalibration/Makefile
+++ b/autocalibration/Makefile
@@ -9,6 +9,33 @@ USES_SCENE_COMMON := yes
 
 include ../common.mk
 
+# Third-party sources are cloned on the host (not inside the Docker build) to avoid
+# GitHub's unauthenticated-download rate limiting hitting container builds.
+RELOC_REPO := https://github.com/cvg/Hierarchical-Localization.git
+RELOC_COMMIT := c13273b
+APRILTAG_REPO := https://github.com/duckietown/lib-dt-apriltags.git
+
+.PHONY: vendor-deps
+vendor-deps:
+	@mkdir -p .vendor
+	@if [ ! -d .vendor/reloc/.git ] || [ "$$(git -C .vendor/reloc rev-parse --short HEAD 2>/dev/null)" != "$(RELOC_COMMIT)" ]; then \
+		rm -rf .vendor/reloc && \
+		echo "==> Cloning Hierarchical-Localization@$(RELOC_COMMIT) (host)..." && \
+		git clone -q $(RELOC_REPO) .vendor/reloc && \
+		git -C .vendor/reloc reset -q --hard $(RELOC_COMMIT); \
+	fi
+	@if [ ! -d .vendor/apriltag-dev/.git ]; then \
+		echo "==> Cloning lib-dt-apriltags (host)..."; \
+		git clone --depth=1 $(APRILTAG_REPO) .vendor/apriltag-dev; \
+	fi
+	@cd .vendor/apriltag-dev && git submodule update --init
+
+build-image: vendor-deps
+
+.PHONY: clean-vendor
+clean-vendor:
+	rm -rf .vendor
+
 .PHONY: test-build
 test-build:
 	$(MAKE) IMAGE="$(TEST_IMAGE)" TARGET="$(TEST_TARGET)"

--- a/mapping/Dockerfile
+++ b/mapping/Dockerfile
@@ -21,8 +21,7 @@ COPY mapping/0001-Run-it-on-CPU.patch /tmp/
 # .vendor/model, keyed off MODEL_TYPE, to avoid GitHub's unauthenticated-download rate limiting.
 COPY mapping/.vendor/model /tmp/vendor-model
 RUN if [ "$MODEL_TYPE" = "mapanything" ]; then \
-        cp -r /tmp/vendor-model ./map-anything && \
-        cd ./map-anything && git apply /tmp/mapanything-version-fix.patch; \
+        cp -r /tmp/vendor-model ./map-anything; \
     elif [ "$MODEL_TYPE" = "vggt" ]; then \
         cp -r /tmp/vendor-model ./vggt && \
         cd ./vggt && git apply /tmp/0001-Run-it-on-CPU.patch; \

--- a/mapping/Dockerfile
+++ b/mapping/Dockerfile
@@ -17,16 +17,19 @@ WORKDIR /tmp
 # Copy the patch files
 COPY mapping/0001-Run-it-on-CPU.patch /tmp/
 
-# Clone and prepare only the selected model
+# Model source is fetched on the host by `make vendor-deps` (see mapping/Makefile) into
+# .vendor/model, keyed off MODEL_TYPE, to avoid GitHub's unauthenticated-download rate limiting.
+COPY mapping/.vendor/model /tmp/vendor-model
 RUN if [ "$MODEL_TYPE" = "mapanything" ]; then \
-        git clone https://github.com/facebookresearch/map-anything.git ./map-anything && \
-        cd ./map-anything && git checkout b84b28f; \
+        cp -r /tmp/vendor-model ./map-anything && \
+        cd ./map-anything && git apply /tmp/mapanything-version-fix.patch; \
     elif [ "$MODEL_TYPE" = "vggt" ]; then \
-        git clone https://github.com/facebookresearch/vggt.git ./vggt && \
-        cd ./vggt && git checkout 44b3afb && git apply /tmp/0001-Run-it-on-CPU.patch; \
+        cp -r /tmp/vendor-model ./vggt && \
+        cd ./vggt && git apply /tmp/0001-Run-it-on-CPU.patch; \
     else \
         echo "Invalid MODEL_TYPE: $MODEL_TYPE. Must be 'mapanything' or 'vggt'" && exit 1; \
-    fi
+    fi && \
+    rm -rf /tmp/vendor-model
 
 # =========================
 # STAGE 2: RUNTIME STAGE

--- a/mapping/Makefile
+++ b/mapping/Makefile
@@ -17,6 +17,40 @@ include ../common.mk
 # Override docker build args to include MODEL_TYPE
 EXTRA_BUILD_ARGS := --build-arg MODEL_TYPE=$(MODEL_TYPE)
 
+# Model source is cloned on the host (not inside the Docker build) to avoid GitHub's
+# unauthenticated-download rate limiting hitting container builds.
+MAPANYTHING_REPO := https://github.com/facebookresearch/map-anything.git
+MAPANYTHING_COMMIT := b84b28f
+VGGT_REPO := https://github.com/facebookresearch/vggt.git
+VGGT_COMMIT := 44b3afb
+
+.PHONY: vendor-deps
+vendor-deps:
+	@mkdir -p .vendor
+	@if [ "$(MODEL_TYPE)" = "mapanything" ]; then \
+		if [ ! -d .vendor/model/.git ] || [ "$$(git -C .vendor/model rev-parse --short HEAD 2>/dev/null)" != "$(MAPANYTHING_COMMIT)" ]; then \
+			rm -rf .vendor/model && \
+			echo "==> Cloning map-anything@$(MAPANYTHING_COMMIT) (host)..." && \
+			git clone -q $(MAPANYTHING_REPO) .vendor/model && \
+			git -C .vendor/model reset -q --hard $(MAPANYTHING_COMMIT); \
+		fi; \
+	elif [ "$(MODEL_TYPE)" = "vggt" ]; then \
+		if [ ! -d .vendor/model/.git ] || [ "$$(git -C .vendor/model rev-parse --short HEAD 2>/dev/null)" != "$(VGGT_COMMIT)" ]; then \
+			rm -rf .vendor/model && \
+			echo "==> Cloning vggt@$(VGGT_COMMIT) (host)..." && \
+			git clone -q $(VGGT_REPO) .vendor/model && \
+			git -C .vendor/model reset -q --hard $(VGGT_COMMIT); \
+		fi; \
+	else \
+		echo "Invalid MODEL_TYPE: $(MODEL_TYPE). Must be 'mapanything' or 'vggt'" && exit 1; \
+	fi
+
+build-image: vendor-deps
+
+.PHONY: clean-vendor
+clean-vendor:
+	rm -rf .vendor
+
 .PHONY: test-build
 test-build:
 	$(MAKE) IMAGE="$(TEST_IMAGE)" TARGET="$(TEST_TARGET)" MODEL_TYPE=$(MODEL_TYPE)


### PR DESCRIPTION
## 📝 Description

Since Dockerhub put more restrictions on unauthenticated requests, images failed to build due to usage of `git clone` inside the container.
This PR moves git operations outside of dockerfiles to bypass these limits by using host git credentials.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**
- [ ] 🚂 **CI**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests

## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
